### PR TITLE
Modify the contents of the *.bib file to avoid bugs

### DIFF
--- a/thesis/example/references/book.bib
+++ b/thesis/example/references/book.bib
@@ -2,11 +2,11 @@
 % book.bib
 %
 
-% @book - A published book
+%at book - A published book
 %   Required: author/editor, title, publisher, year.
 %   Optional: volume/number, series, edition.
 
-%@book{label:book,
+%at book{label:book,
 %    author    = "",
 %    title     = "",
 %    publisher = "",

--- a/thesis/example/references/misc.bib
+++ b/thesis/example/references/misc.bib
@@ -3,11 +3,11 @@
 % (miscellaneous, everything)
 %
 %
-% %@misc - Template useful for other kinds of publication
+%at misc - Template useful for other kinds of publication
 %   Required fields: none
 %   Optional fields: author, title, howpublished, month, year, note.
 %
-%@misc{label:misc,
+%at misc{label:misc,
 %    %author    = "",
 %    %title     = "",
 %    %howpublished = "",
@@ -17,7 +17,7 @@
 %}
 %
 %  E.g (Website)
-%    @misc{website:google,
+%    at misc{website:google,
 %      author = {},
 %      title = {{Google - Homepage}},
 %      howpublished = "http://www.google.com/",
@@ -65,14 +65,6 @@
   author = {},
   title = {{臺灣大學碩博士論文 XeLaTeX 模版}},
   howpublished = "\url{https://github.com/tzhuan/ntu-thesis/wiki}",
-  year = {},
-  note = ""
-}
-% -----------------------------------------------------------------------------
-@misc{web:latex:template:ntu,
-  author = {},
-  title = {{關於LaTeX 的一些筆記 - 元智大學}},
-  howpublished = "\url{http://exciton.eo.yzu.edu.tw/~lab/latex/latex_note.html}",
   year = {},
   note = ""
 }

--- a/thesis/example/references/paper.bib
+++ b/thesis/example/references/paper.bib
@@ -2,10 +2,10 @@
 % paper.bib
 %
 %
-% @inproceedings - An article in a conference proceedings.
+%at inproceedings - An article in a conference proceedings.
 %   Required: author, title, booktitle, year.
 %   Optional fields: editor, volume/number, series, pages, address, month, organization, publisher, note.
-%@inproceedings{Xinproceedings,
+%at inproceedings{Xinproceedings,
 %	author		= "",
 %	title		= "",
 %	booktitle	= "",


### PR DESCRIPTION
Compiler version：
BibTeX, Version 0.99d
Texmaker_5.0.3_Win_x64
.
The @ symbol in the *.bib annotation will cause the compiler to make an error.
Currently change all "@" symbol in *.bib to "at"
.
Also in the file misc.bib
Label repeated web:latex:template:ntu
One has been removed to avoid errors