### PR TITLE
docs: close post-release optimization review

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 V2 已完成更新並在 [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest) 發布；它保留 1.x 的公開設定方式和 XeLaTeX 使用路徑，同時整理了樣式、相容層、測試及學生下載套件。
 
-現有 [Overleaf Gallery 模版](https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn) 已公開使用，但 V2 更新尚未上載到原本的 Overleaf project，亦尚未提交作 Gallery update review。在完成原 project 更新、重新編譯、提交及 Overleaf 審批前，最新 V2 source 和學生套件仍以 [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest) 為準；詳細發佈狀態記錄在 [`docs/overleaf-distribution.md`](docs/overleaf-distribution.md)。
+現有 [Overleaf Gallery 模版](https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn) 已公開使用。V2 更新已由維護者確認上載到原本的 Overleaf project，並重新提交作 Gallery update review，現正等待 Overleaf 回覆及審批。在 Overleaf 批准更新並完成公開 read-back 前，最新 V2 source 和學生套件仍以 [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest) 為準；詳細發佈狀態記錄在 [`docs/overleaf-distribution.md`](docs/overleaf-distribution.md)。
 
 V2 亦優先整理了 **Style Customization 自定成其他學校的模版**：共用樣式、成大規則和自訂學校 profile 已分開，修改其他學校所需格式時不必直接改動整個成大樣式層。
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 V2 已完成更新並在 [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest) 發布；它保留 1.x 的公開設定方式和 XeLaTeX 使用路徑，同時整理了樣式、相容層、測試及學生下載套件。
 
-現有 [Overleaf Gallery 模版](https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn) 已公開使用，V2 更新亦已透過原本的 Overleaf project 提交作 Gallery update review。在 Overleaf 完成更新審核前，最新 V2 source 和學生套件仍以 [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest) 為準；詳細發佈狀態記錄在 [`docs/overleaf-distribution.md`](docs/overleaf-distribution.md)。
+現有 [Overleaf Gallery 模版](https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn) 已公開使用，但 V2 更新尚未上載到原本的 Overleaf project，亦尚未提交作 Gallery update review。在完成原 project 更新、重新編譯、提交及 Overleaf 審批前，最新 V2 source 和學生套件仍以 [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest) 為準；詳細發佈狀態記錄在 [`docs/overleaf-distribution.md`](docs/overleaf-distribution.md)。
 
 V2 亦優先整理了 **Style Customization 自定成其他學校的模版**：共用樣式、成大規則和自訂學校 profile 已分開，修改其他學校所需格式時不必直接改動整個成大樣式層。
 

--- a/docs/overleaf-distribution.md
+++ b/docs/overleaf-distribution.md
@@ -1,8 +1,8 @@
 # Overleaf distribution decision
 
-Status: Gallery template published; V2 update submitted through the original project and pending update review
+Status: Gallery template published; V2 Gallery package prepared, but the original project has not yet been updated or resubmitted
 
-Checked: 2026-07-17
+Checked: 2026-07-18
 
 ## Decision
 
@@ -90,6 +90,36 @@ The cover, abstract, and acknowledgements pages were rendered to images and visu
 
 The Overleaf import artifacts remain under ignored `build/overleaf/`; they are not GitHub Release assets or permanent public URLs.
 
+### Prepared V2 Gallery result on 2026-07-18
+
+The V2 Gallery package was regenerated from clean merged source commit
+`a7950358b017e2dc813d137c1a8a193a3d1f5704` with:
+
+```bash
+just overleaf-gallery main-a795035
+```
+
+The verified artifact is:
+
+- `ncku-thesis-template-latex-overleaf-gallery-main-a795035.zip`;
+- 70 regular files;
+- 305,449 editable bytes;
+- 4,691,706 ZIP bytes;
+- SHA-256 `cd13e6576f8efa534c4e38a47f9b33db3aa41bdd1d6ecfafb90dd51c57fbbeab`;
+- an 11-page A4 StudentMode PDF from a clean extracted direct XeLaTeX build;
+- no teaching corpus, second main document, generated PDF, Draft marker,
+  institutional logo watermark, unresolved references/citations, or
+  maintainer-only repository tooling.
+
+Cover and representative front-matter pages were rendered and visually checked
+without clipping, overlap, Draft/logo marks, or broken Chinese/Latin fonts. The
+visible red PDF hyperlink borders on the table of contents match the existing
+public Gallery behavior and are not a new V2 regression.
+
+This is the **prepared** state only. The ZIP has not been uploaded into the
+original Overleaf project, the project has not been recompiled with this source,
+and no V2 Gallery update has been submitted.
+
 ## Required Overleaf settings
 
 After ZIP upload/import:
@@ -131,7 +161,7 @@ The Gallery project was submitted on 2026-07-12 and approved/published by Overle
 
 <https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn>
 
-Owner-confirmed on 2026-07-17: the V2 update has been submitted through that original Overleaf project and is pending Gallery update review. Until Overleaf approves the update and the public template is independently read back, GitHub Releases remains the canonical source for the latest V2 student package. Do not describe the public Gallery copy as V2 merely because the update has been submitted.
+Owner-corrected on 2026-07-18: the V2 update has **not** been uploaded to the original Overleaf project and has **not** been submitted for Gallery update review. A verified Gallery package is prepared, but GitHub Releases remains the canonical source for the latest V2 student package until the original project is updated, recompiled, resubmitted, approved, and independently read back. Do not describe the public Gallery copy as V2 before those steps are complete.
 
 Operational rules:
 

--- a/docs/overleaf-distribution.md
+++ b/docs/overleaf-distribution.md
@@ -1,6 +1,6 @@
 # Overleaf distribution decision
 
-Status: Gallery template published; V2 Gallery package prepared, but the original project has not yet been updated or resubmitted
+Status: Gallery template published; V2 package owner-confirmed uploaded to the original project and resubmitted, pending Overleaf response and public read-back
 
 Checked: 2026-07-18
 
@@ -116,9 +116,11 @@ without clipping, overlap, Draft/logo marks, or broken Chinese/Latin fonts. The
 visible red PDF hyperlink borders on the table of contents match the existing
 public Gallery behavior and are not a new V2 regression.
 
-This is the **prepared** state only. The ZIP has not been uploaded into the
-original Overleaf project, the project has not been recompiled with this source,
-and no V2 Gallery update has been submitted.
+Owner-confirmed on 2026-07-18: the prepared V2 package was uploaded into the
+original Overleaf project and resubmitted for Gallery update review. The
+authenticated project settings and compile result were not independently read
+back in this session, so this is an owner-confirmed **submitted** state rather
+than independently observed approval. Overleaf's response is pending.
 
 ## Required Overleaf settings
 
@@ -161,7 +163,7 @@ The Gallery project was submitted on 2026-07-12 and approved/published by Overle
 
 <https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn>
 
-Owner-corrected on 2026-07-18: the V2 update has **not** been uploaded to the original Overleaf project and has **not** been submitted for Gallery update review. A verified Gallery package is prepared, but GitHub Releases remains the canonical source for the latest V2 student package until the original project is updated, recompiled, resubmitted, approved, and independently read back. Do not describe the public Gallery copy as V2 before those steps are complete.
+Owner-confirmed on 2026-07-18: the verified V2 package was uploaded to the original Overleaf project and resubmitted for Gallery update review; Overleaf's response is pending. The public Gallery page and PDF were independently checked immediately afterward and still expose the pre-V2 copy (11-page PDF creation date `2026-07-12`, SHA-256 `24dcf2e9a6df0360151cbdf1757fbb7d2f583e0d4374479a538dbb5e4d10b702`). GitHub Releases therefore remains the canonical source for the latest V2 student package until Overleaf approves the update and the public Gallery copy is independently read back. Submitted does not mean approved or published.
 
 Operational rules:
 

--- a/docs/source-optimization-review.md
+++ b/docs/source-optimization-review.md
@@ -14,10 +14,11 @@ authorization to change the class/package structure, engine, public API, or PDF
 accessibility claims; each would require a separate owner-approved Intent and
 validation boundary.
 
-The original public Overleaf Gallery template remains published. The V2 update
-was submitted through the original project and is still pending Gallery review;
-GitHub Releases remains the canonical V2 package until the public Gallery copy
-is approved and independently read back.
+The original public Overleaf Gallery template remains published. A verified V2
+Gallery package is prepared, but it has not been uploaded to the original
+project or submitted for Gallery update review. GitHub Releases remains the
+canonical V2 package until the original project is updated, resubmitted,
+approved, and independently read back.
 
 ## Implementation status
 

--- a/docs/source-optimization-review.md
+++ b/docs/source-optimization-review.md
@@ -1,8 +1,23 @@
 # XeLaTeX source optimization and modernization review
 
-Status: implementation in progress
+Status: completed and shipped in [`v2.0.0.260717130231`](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.0.260717130231); P3 experiments are deferred and inactive
 
-Checked: 2026-07-15
+Checked: 2026-07-18
+
+## Closure
+
+The compatibility-bounded P0--P2 work from this review is complete and its
+maintained implementation record now lives under [`features/v2/`](features/v2/).
+This document remains the evidence and prioritization record for the measured
+modernization work. The P3 ideas below are not active requirements, todos, or
+authorization to change the class/package structure, engine, public API, or PDF
+accessibility claims; each would require a separate owner-approved Intent and
+validation boundary.
+
+The original public Overleaf Gallery template remains published. The V2 update
+was submitted through the original project and is still pending Gallery review;
+GitHub Releases remains the canonical V2 package until the public Gallery copy
+is approved and independently read back.
 
 ## Implementation status
 
@@ -231,9 +246,10 @@ The identical full-width minipage plus zero-line `mdframed`/opacity wrapper is n
   NCKU uses Master 3--5 and Doctoral 5--9, while neutral/custom keeps the generic
   2--9 renderer capacity. A focused boundary fixture rejects future drift.
 
-## P3 — major-version experiments
+## P3 — inactive major-version experiments
 
-Do not mix these into v1.x maintenance.
+These are research directions, not active requirements or todos. Do not mix
+them into v2 maintenance; each requires a separate owner-approved experiment.
 
 ### 1. Formal class/package structure
 
@@ -264,15 +280,19 @@ A future isolated experiment may evaluate LuaLaTeX plus `\DocumentMetadata` befo
 - Do not precompile the preamble before measuring whether its complexity and cache invalidation are worth the maintenance cost.
 - Do not rewrite all legacy commands to `expl3` in one change.
 
-## Recommended implementation order
+## Completed execution order and deferred boundary
 
-1. Add sectioning, numbering/reference, oral-state, metadata, and font/CJK fixtures.
-2. Add `just watch` and editor documentation.
-3. Benchmark an optional non-final chapter preview.
-4. Apply isolated low-risk engine/metadata/font cleanup.
-5. Consolidate small helpers and dead private code.
-6. Refactor numbering, theorem, and float internals one subsystem at a time with PDF/text baselines.
-7. Evaluate class/package, `l3build`, `latex-dev`, and tagged-PDF work only on a major-version experiment line.
+1. Completed: sectioning, numbering/reference, oral-state, metadata, and
+   font/CJK fixtures.
+2. Completed: `just watch` and editor documentation.
+3. Measured and rejected: an optional non-final chapter preview did not justify
+   its additional numbering/reference risk.
+4. Completed: isolated low-risk engine/metadata/font cleanup.
+5. Completed: small-helper consolidation and dead private-code removal.
+6. Completed: bounded numbering, theorem, and float hardening with PDF/text
+   baselines.
+7. Deferred and inactive: class/package, `l3build`, `latex-dev`, and tagged-PDF
+   experiments.
 
 ## Acceptance gates for every implementation slice
 

--- a/docs/source-optimization-review.md
+++ b/docs/source-optimization-review.md
@@ -14,11 +14,11 @@ authorization to change the class/package structure, engine, public API, or PDF
 accessibility claims; each would require a separate owner-approved Intent and
 validation boundary.
 
-The original public Overleaf Gallery template remains published. A verified V2
-Gallery package is prepared, but it has not been uploaded to the original
-project or submitted for Gallery update review. GitHub Releases remains the
-canonical V2 package until the original project is updated, resubmitted,
-approved, and independently read back.
+The original public Overleaf Gallery template remains published. The verified
+V2 Gallery package was owner-confirmed uploaded to the original project and
+resubmitted for Gallery update review on 2026-07-18; Overleaf's response is
+pending. GitHub Releases remains the canonical V2 package until the update is
+approved and the public Gallery copy is independently read back.
 
 ## Implementation status
 


### PR DESCRIPTION
## Intent

Close the completed XeLaTeX optimization review after the V2 stable release and keep the Overleaf update lifecycle truthful.

## Changes

- mark the P0–P2 optimization review complete and link the immutable V2 release
- make P3 class/package, l3build, latex-dev, engine, and tagged-PDF ideas explicitly deferred and inactive
- record the verified Gallery package from exact merged source `a7950358b017e2dc813d137c1a8a193a3d1f5704`
- record the owner-confirmed upload to the original Overleaf project and Gallery resubmission on 2026-07-18
- keep the current state bounded as submitted/pending response, not approved or publicly published
- preserve GitHub Releases as canonical until Overleaf approval and independent public read-back

## Gallery artifact and submission state

- `ncku-thesis-template-latex-overleaf-gallery-main-a795035.zip`
- 70 regular files; 305,449 editable bytes; 4,691,706 ZIP bytes
- SHA-256 `cd13e6576f8efa534c4e38a47f9b33db3aa41bdd1d6ecfafb90dd51c57fbbeab`
- clean extracted direct XeLaTeX build: 11 A4 pages
- owner-confirmed uploaded to the original project and resubmitted; Overleaf response pending
- authenticated project settings/compile result not independently read back in this session
- public page/PDF still expose the pre-V2 copy immediately after submission: PDF creation date 2026-07-12, SHA-256 `24dcf2e9a6df0360151cbdf1757fbb7d2f583e0d4374479a538dbb5e4d10b702`

## Validation

- owner-confirmed submission-state assertions: PASS
- local Markdown links: PASS
- `git diff --check`: PASS
- local `just test` on unchanged TeX source: PASS
- canonical Gallery packaging and independent extracted XeLaTeX/visual verification: PASS

## Scope boundary

Documentation plus an ignored/local delivery artifact only. No TeX source/output change, release, tag, Overleaf approval claim, PR merge, or P3 implementation.