### PR TITLE
ci: pin test runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Check out source


### PR DESCRIPTION
## Intent

Refresh the repository dependency/runtime surface while Overleaf review is pending, without changing TeX source, release artifacts, or user-visible output.

## Dependency audit

Official latest stable releases checked on 2026-07-18:

- `actions/checkout@v7` resolves to `v7.0.0` — current
- `actions/upload-artifact@v7` resolves to `v7.0.1` — current
- `actions/download-artifact@v8` resolves to `v8.0.1` — current
- `xu-cheng/texlive-action@v3` — current
- all three JavaScript actions use Node 24
- TeX runtime remains the declared `TeX Live 2026`

No fake version bump is applied where the existing major tag already resolves to the latest patch.

## Change

- replace Test workflow `ubuntu-latest` with explicit `ubuntu-24.04`
- align Test with the already-pinned Release workflow and documented x64 runner architecture
- prevent a future `-latest` label migration from changing the required test environment silently

## Validation

- workflow runtime/action-ref assertions: PASS
- official release/tag resolution checks: PASS
- `git diff --check`: PASS
- `just ci`: PASS

## Scope boundary

No LaTeX package/source change, vendored-library replacement, generated artifact, Overleaf mutation, tag, release, deploy, or merge.