### PR TITLE
refactor: use expl3 for counter-style dispatch

### DIFF
--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -24,6 +24,8 @@ student project shape, and complete audited 1.x public API through the 2.x line.
 - [`numbering-hardening.md`](numbering-hardening.md)
 - [`full-review-repairs.md`](full-review-repairs.md)
 - [`super-optimization.md`](super-optimization.md)
+- [`expl3-internals.md`](expl3-internals.md) — bounded post-release internal
+  modernization research and its first output-neutral dispatcher slice.
 
 ## Current machine-checked contracts
 

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -85,8 +85,8 @@ The slice must preserve:
 5. dynamic counter values and frozen counter names;
 6. default/custom general and appendix title/getter output;
 7. figure/table/equation numbering idempotence;
-8. 271-page A4 canonical output, text, bounding boxes, fonts, and representative
-   rasters;
+8. 271-page A4 canonical output, text, bounding boxes, fonts, and all-page
+   fixed-DPI raster output;
 9. V1 API and unchanged-project migration contracts;
 10. the existing package graph boundary: `ifthen` remains active and no new
     package is added.
@@ -105,7 +105,8 @@ The retained implementation passed:
   theorem, and custom-style gates;
 - canonical 271-page A4 text identity;
 - canonical normalized bounding-box and font-table identity;
-- identical 150-DPI rasters for pages 1, 2, 82, and 258--261;
+- identical 120-DPI raster output for all 271 canonical pages, plus identical
+  150-DPI representative rasters for pages 1, 2, 82, and 258--261;
 - active-graph assertions: `expl3`, `ifthen`, `pgfkeys`, and `xparse` active;
   `fp` and `apptools` absent.
 

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,0 +1,123 @@
+# Incremental `expl3` Internal Modernization
+
+Status: first bounded slice implemented and validated; pending review
+
+## Intent
+
+Modernize legacy internal control flow only where the behavior is finite, already
+fixture-protected, and output-neutral. Preserve the complete audited 1.x public
+API through the 2.x line, direct XeLaTeX student builds, TeX Live 2026,
+Overleaf compatibility, and canonical PDF output.
+
+This is not approval for a repository-wide rewrite, a class/package redesign,
+LuaLaTeX migration, or a blanket `pgfkeys`/`ifthen` conversion.
+
+## Starting evidence
+
+The first audit used immutable baseline
+`a7950358b017e2dc813d137c1a8a193a3d1f5704` and found:
+
+- 187 literal `\ifthenelse` calls across 24 active template files;
+- 58 `\pgfkeys`/`\pgfkeysvalueof` references across seven files;
+- 49 document-command declarations, including protected 2.x compatibility
+  signatures that still require explicit `xparse` for `G{...}` arguments;
+- direct `etoolbox` helpers in numbering code, while `mdframed` also keeps
+  `etoolbox` in the active package graph transitively;
+- `expl3`, `ifthen`, `pgfkeys`, `xparse`, and `etoolbox` active in the canonical
+  `.fls`; legacy `fp` and vendored `apptools` absent.
+
+The LaTeX Project's [`interface3` reference](https://mirror.math.princeton.edu/pub/CTAN/macros/latex/required/l3kernel/interface3.pdf),
+released 2026-06-18, defines `\str_case_e:nn` as a fully expanding string-case
+dispatch that does nothing when no case matches. Those semantics match the
+existing counter-style dispatcher: style names can arrive through pgf-stored
+macros, while unknown or empty styles are deliberate no-ops.
+
+## Candidate decisions
+
+### Selected: bounded counter-style dispatch
+
+`\AppendCounterStringToFormatString` had seven sequential
+`\ifthenelse{\equal{...}{...}}` branches for:
+
+```text
+ChiNum / Tiangan / Arabic / LowerRoman / UpperRoman / LowerAlph / UpperAlph
+```
+
+The implementation now uses one `\str_case_e:nn` table. The public command name,
+three-argument LaTeX signature, formatter helpers, dynamic counter behavior, and
+unknown-style no-op are unchanged. The focused test also rejects a return to
+sequential `ifthen` dispatch.
+
+### Retained: explicit `xparse`
+
+The LaTeX kernel provides modern document-command interfaces, but it deliberately
+does not provide all legacy `xparse` argument types. Protected 2.x commands still
+use `G{...}` signatures, so removing explicit `xparse` would make compatibility
+transitive and fragile rather than modern.
+
+### Deferred: broad `ifthen` conversion
+
+After this slice, 180 literal `\ifthenelse` calls remain across independent
+cover, chapter, float, bibliography, font, theorem, oral, and style behavior.
+They do not form one bounded state machine. Each future conversion needs its own
+fixture and visible-output proof; a mechanical global rewrite is rejected.
+
+### Deferred: `pgfkeys` to `l3keys`
+
+The seven key families expose different defaulting, storage, repeated-setup, and
+unknown-key behaviors. Migrating one family is justified only after freezing its
+complete parse and error contract. This slice does not change key parsing.
+
+### Retained: `etoolbox`
+
+Replacing one direct helper would not remove the package because `mdframed`
+loads it transitively, and numbering still uses its append and boolean-expression
+helpers. No dependency-removal benefit is claimed.
+
+## Compatibility expectations
+
+The slice must preserve:
+
+1. the audited public declaration and three-argument signature;
+2. all seven counter styles;
+3. full expansion of macro-valued style names;
+4. unknown and empty style no-ops;
+5. dynamic counter values and frozen counter names;
+6. default/custom general and appendix title/getter output;
+7. figure/table/equation numbering idempotence;
+8. 271-page A4 canonical output, text, bounding boxes, fonts, and representative
+   rasters;
+9. V1 API and unchanged-project migration contracts;
+10. the existing package graph boundary: `ifthen` remains active and no new
+    package is added.
+
+## Validation result
+
+The retained implementation passed:
+
+- focused one-page numbering contract;
+- all seven style markers, macro-valued styles, unknown no-op, dynamic counters,
+  repeated setup, and figure/table/equation idempotence;
+- focused text, normalized bounding boxes, font table, and 200-DPI raster
+  identity against the baseline;
+- fresh `just ci`, including V1 API, unchanged-project migration, diagnostics,
+  student archive, engine, metadata, font/CJK, student-mode, watermark, float,
+  theorem, and custom-style gates;
+- canonical 271-page A4 text identity;
+- canonical normalized bounding-box and font-table identity;
+- identical 150-DPI rasters for pages 1, 2, 82, and 258--261;
+- active-graph assertions: `expl3`, `ifthen`, `pgfkeys`, and `xparse` active;
+  `fp` and `apptools` absent.
+
+The local source delta is seven fewer `\ifthenelse` calls in
+`cmd-numbering.tex` (15 to 8), one new bounded `expl3` string case, no public API
+change, and no PDF-output change.
+
+## Next research slice
+
+Do not continue by count alone. Rank candidates by removable dependency cost,
+finite semantics, existing fixture coverage, and output risk. A small isolated
+`pgfkeys` family may be the next research target only after its default,
+macro-expansion, unknown-key, and repeated-setup contract is captured; otherwise
+prefer another finite `ifthen` dispatcher. Keep each slice independently
+revertible.

--- a/scripts/test/check-numbering-contract.py
+++ b/scripts/test/check-numbering-contract.py
@@ -92,10 +92,26 @@ def main() -> None:
         source.count(r"\begin{comment}") == 0,
         "runtime-dead numbering comment blocks reappeared",
     )
+    dispatcher = source.split(r"\newcommand\AppendCounterStringToFormatString", 1)[1].split(
+        r"\newcommand\SetupTitleNumberFormatString", 1
+    )[0]
+    require(r"\str_case_e:nn" in dispatcher, "counter-style dispatch is not an expl3 string case")
+    require(r"\ifthenelse" not in dispatcher, "counter-style dispatch regained sequential ifthen tests")
+    for style in (
+        "ChiNum",
+        "Tiangan",
+        "Arabic",
+        "LowerRoman",
+        "UpperRoman",
+        "LowerAlph",
+        "UpperAlph",
+    ):
+        require(dispatcher.count(f"{{{style}}}") == 1, f"counter-style case changed: {style}")
 
     print(
         "Numbering contract PASS: default/custom general+appendix titles/getters, "
-        "dynamic counters, 7 styles, F/T/E idempotence, unknown/empty no-op, A4 single page"
+        "dynamic counters, 7-style expl3 dispatch, F/T/E idempotence, "
+        "unknown/empty no-op, A4 single page"
     )
 
 

--- a/thesis/template/command/cmd-numbering.tex
+++ b/thesis/template/command/cmd-numbering.tex
@@ -113,24 +113,31 @@
 } % End of \newcommand{}
 \makeatother
 
-% Append counter value in style to string
+% Append counter value in style to string. The selected style can arrive through
+% a pgf-stored macro, so use the expanding string-case form. Unknown or empty
+% styles deliberately remain no-ops, matching the public compatibility contract.
+\ExplSyntaxOn
 \newcommand\AppendCounterStringToFormatString[3]
-{%
-  \ifthenelse{\equal{#2}{ChiNum}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\zhnum}{#3}}{}%
-  \ifthenelse{\equal{#2}{Tiangan}}{%
-    \NCKUPrivateAppendCounterValueFormatter{#1}{\zhtiangan}{#3}}{}%
-  \ifthenelse{\equal{#2}{Arabic}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\arabic}{#3}}{}%
-  \ifthenelse{\equal{#2}{LowerRoman}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\roman}{#3}}{}%
-  \ifthenelse{\equal{#2}{UpperRoman}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\Roman}{#3}}{}%
-  \ifthenelse{\equal{#2}{LowerAlph}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\alph}{#3}}{}%
-  \ifthenelse{\equal{#2}{UpperAlph}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\Alph}{#3}}{}%
+{
+  \str_case_e:nn {#2}
+  {
+    {ChiNum}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\zhnum}{#3}}
+    {Tiangan}
+      {\NCKUPrivateAppendCounterValueFormatter{#1}{\zhtiangan}{#3}}
+    {Arabic}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\arabic}{#3}}
+    {LowerRoman}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\roman}{#3}}
+    {UpperRoman}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\Roman}{#3}}
+    {LowerAlph}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\alph}{#3}}
+    {UpperAlph}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\Alph}{#3}}
+  }
 } % End of \newcommand{}
+\ExplSyntaxOff
 
 \newcommand\SetupTitleNumberFormatString[3]
 {%


### PR DESCRIPTION
## Intent

Resume the owner-requested legacy LaTeX implementation replacement research with one bounded, output-neutral `expl3` slice. This is not a repository-wide rewrite.

## Research result

- keep explicit `xparse`: protected 2.x public commands still require `G{...}` argument types unavailable from the kernel interface alone
- defer broad `ifthen` conversion: baseline has 187 literal calls across 24 active files
- defer `pgfkeys` to `l3keys`: 58 references across seven key families need separate parse/default/error contracts
- retain `etoolbox`: direct numbering uses remain and `mdframed` loads it transitively
- select the finite seven-value counter-style dispatcher as the first safe wedge

The official LaTeX Project `interface3` reference defines `\str_case_e:nn` as fully expanding its compared strings and doing nothing when no case matches, matching the existing macro-valued-style and unknown-style semantics.

## Change

- replace seven sequential `ifthenelse` comparisons in `\AppendCounterStringToFormatString` with one `\str_case_e:nn` table
- preserve the public name and three-argument declaration
- extend the focused numbering checker to enforce the seven-case `expl3` dispatcher and reject sequential `ifthen` regression
- add `docs/features/v2/expl3-internals.md` with the candidate decisions, boundaries, evidence, and next-slice criteria

Source delta in `cmd-numbering.tex`: `ifthenelse` 15 → 8; one bounded `expl3` string case added. The global `ifthen` package remains active; no dependency-removal claim is made.

## Validation

- focused numbering contract: PASS
- 7 styles, macro-valued styles, unknown no-op, dynamic counters, repeated setup, F/T/E idempotence: PASS
- focused text, normalized bbox, fonts, and 200-DPI raster: identical
- fresh `just ci`: PASS
- V1 API: 597 LaTeX/xparse + 65 literal def-style declarations preserved
- V1 unchanged-project migration: PASS
- canonical PDF: 271 A4 pages; text, normalized bbox, and fonts identical
- canonical 120-DPI rasters: all 271/271 pages byte-identical
- higher-resolution 150-DPI representative rasters pages 1, 2, 82, 258–261: 7/7 identical
- `just release review`: PASS; exact student tree and six generated example PDFs verified
- extracted student ZIP direct XeLaTeX build: 271 A4 pages, SyncTeX present, resolved refs, final-ready cover
- active graph: `expl3`, `ifthen`, `pgfkeys`, `xparse` active; `fp`, `apptools` absent

## Acceptance rule

Internal implementation may change only when the complete PDF remains output-neutral. Any page-count, page-size, text, bounding-box position, font identity, or raster difference rejects the slice and requires rollback or separate visible-change approval.

## Scope boundary

No public API change, broad `ifthen` rewrite, `pgfkeys` migration, class/package redesign, LuaLaTeX migration, Overleaf mutation, tag, release, deploy, or merge.
