### PR TITLE
refactor: use l3keys for single-figure options

### DIFF
--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -24,6 +24,8 @@ student project shape, and complete audited 1.x public API through the 2.x line.
 - [`numbering-hardening.md`](numbering-hardening.md)
 - [`full-review-repairs.md`](full-review-repairs.md)
 - [`super-optimization.md`](super-optimization.md)
+- [`expl3-internals.md`](expl3-internals.md) — bounded post-release internal
+  modernization research and its first output-neutral dispatcher slice.
 
 ## Current machine-checked contracts
 

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -85,8 +85,8 @@ The slice must preserve:
 5. dynamic counter values and frozen counter names;
 6. default/custom general and appendix title/getter output;
 7. figure/table/equation numbering idempotence;
-8. 271-page A4 canonical output, text, bounding boxes, fonts, and representative
-   rasters;
+8. 271-page A4 canonical output, text, bounding boxes, fonts, and all-page
+   fixed-DPI raster output;
 9. V1 API and unchanged-project migration contracts;
 10. the existing package graph boundary: `ifthen` remains active and no new
     package is added.
@@ -105,7 +105,8 @@ The retained implementation passed:
   theorem, and custom-style gates;
 - canonical 271-page A4 text identity;
 - canonical normalized bounding-box and font-table identity;
-- identical 150-DPI rasters for pages 1, 2, 82, and 258--261;
+- identical 120-DPI raster output for all 271 canonical pages, plus identical
+  150-DPI representative rasters for pages 1, 2, 82, and 258--261;
 - active-graph assertions: `expl3`, `ifthen`, `pgfkeys`, and `xparse` active;
   `fp` and `apptools` absent.
 

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,0 +1,123 @@
+# Incremental `expl3` Internal Modernization
+
+Status: first bounded slice implemented and validated; pending review
+
+## Intent
+
+Modernize legacy internal control flow only where the behavior is finite, already
+fixture-protected, and output-neutral. Preserve the complete audited 1.x public
+API through the 2.x line, direct XeLaTeX student builds, TeX Live 2026,
+Overleaf compatibility, and canonical PDF output.
+
+This is not approval for a repository-wide rewrite, a class/package redesign,
+LuaLaTeX migration, or a blanket `pgfkeys`/`ifthen` conversion.
+
+## Starting evidence
+
+The first audit used immutable baseline
+`a7950358b017e2dc813d137c1a8a193a3d1f5704` and found:
+
+- 187 literal `\ifthenelse` calls across 24 active template files;
+- 58 `\pgfkeys`/`\pgfkeysvalueof` references across seven files;
+- 49 document-command declarations, including protected 2.x compatibility
+  signatures that still require explicit `xparse` for `G{...}` arguments;
+- direct `etoolbox` helpers in numbering code, while `mdframed` also keeps
+  `etoolbox` in the active package graph transitively;
+- `expl3`, `ifthen`, `pgfkeys`, `xparse`, and `etoolbox` active in the canonical
+  `.fls`; legacy `fp` and vendored `apptools` absent.
+
+The LaTeX Project's [`interface3` reference](https://mirror.math.princeton.edu/pub/CTAN/macros/latex/required/l3kernel/interface3.pdf),
+released 2026-06-18, defines `\str_case_e:nn` as a fully expanding string-case
+dispatch that does nothing when no case matches. Those semantics match the
+existing counter-style dispatcher: style names can arrive through pgf-stored
+macros, while unknown or empty styles are deliberate no-ops.
+
+## Candidate decisions
+
+### Selected: bounded counter-style dispatch
+
+`\AppendCounterStringToFormatString` had seven sequential
+`\ifthenelse{\equal{...}{...}}` branches for:
+
+```text
+ChiNum / Tiangan / Arabic / LowerRoman / UpperRoman / LowerAlph / UpperAlph
+```
+
+The implementation now uses one `\str_case_e:nn` table. The public command name,
+three-argument LaTeX signature, formatter helpers, dynamic counter behavior, and
+unknown-style no-op are unchanged. The focused test also rejects a return to
+sequential `ifthen` dispatch.
+
+### Retained: explicit `xparse`
+
+The LaTeX kernel provides modern document-command interfaces, but it deliberately
+does not provide all legacy `xparse` argument types. Protected 2.x commands still
+use `G{...}` signatures, so removing explicit `xparse` would make compatibility
+transitive and fragile rather than modern.
+
+### Deferred: broad `ifthen` conversion
+
+After this slice, 180 literal `\ifthenelse` calls remain across independent
+cover, chapter, float, bibliography, font, theorem, oral, and style behavior.
+They do not form one bounded state machine. Each future conversion needs its own
+fixture and visible-output proof; a mechanical global rewrite is rejected.
+
+### Deferred: `pgfkeys` to `l3keys`
+
+The seven key families expose different defaulting, storage, repeated-setup, and
+unknown-key behaviors. Migrating one family is justified only after freezing its
+complete parse and error contract. This slice does not change key parsing.
+
+### Retained: `etoolbox`
+
+Replacing one direct helper would not remove the package because `mdframed`
+loads it transitively, and numbering still uses its append and boolean-expression
+helpers. No dependency-removal benefit is claimed.
+
+## Compatibility expectations
+
+The slice must preserve:
+
+1. the audited public declaration and three-argument signature;
+2. all seven counter styles;
+3. full expansion of macro-valued style names;
+4. unknown and empty style no-ops;
+5. dynamic counter values and frozen counter names;
+6. default/custom general and appendix title/getter output;
+7. figure/table/equation numbering idempotence;
+8. 271-page A4 canonical output, text, bounding boxes, fonts, and representative
+   rasters;
+9. V1 API and unchanged-project migration contracts;
+10. the existing package graph boundary: `ifthen` remains active and no new
+    package is added.
+
+## Validation result
+
+The retained implementation passed:
+
+- focused one-page numbering contract;
+- all seven style markers, macro-valued styles, unknown no-op, dynamic counters,
+  repeated setup, and figure/table/equation idempotence;
+- focused text, normalized bounding boxes, font table, and 200-DPI raster
+  identity against the baseline;
+- fresh `just ci`, including V1 API, unchanged-project migration, diagnostics,
+  student archive, engine, metadata, font/CJK, student-mode, watermark, float,
+  theorem, and custom-style gates;
+- canonical 271-page A4 text identity;
+- canonical normalized bounding-box and font-table identity;
+- identical 150-DPI rasters for pages 1, 2, 82, and 258--261;
+- active-graph assertions: `expl3`, `ifthen`, `pgfkeys`, and `xparse` active;
+  `fp` and `apptools` absent.
+
+The local source delta is seven fewer `\ifthenelse` calls in
+`cmd-numbering.tex` (15 to 8), one new bounded `expl3` string case, no public API
+change, and no PDF-output change.
+
+## Next research slice
+
+Do not continue by count alone. Rank candidates by removable dependency cost,
+finite semantics, existing fixture coverage, and output risk. A small isolated
+`pgfkeys` family may be the next research target only after its default,
+macro-expansion, unknown-key, and repeated-setup contract is captured; otherwise
+prefer another finite `ifthen` dispatcher. Keep each slice independently
+revertible.

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,6 +1,6 @@
 # Incremental `expl3` Internal Modernization
 
-Status: first bounded slice implemented and validated; pending review
+Status: first two bounded slices implemented and validated; pending review
 
 ## Intent
 
@@ -48,6 +48,20 @@ three-argument LaTeX signature, formatter helpers, dynamic counter behavior, and
 unknown-style no-op are unchanged. The focused test also rejects a return to
 sequential `ifthen` dispatch.
 
+### Selected follow-up: single-figure key parsing
+
+The seven-key `/InsertFigure` family was the smallest independently reversible
+`pgfkeys` candidate. Before changing its implementation, the float fixture froze
+all literal defaults, expanded macro-valued storage, reset-on-repeat behavior,
+and unknown-key hard-error behavior behind one private parser seam.
+
+The family now uses `\keys_define:nn`, `\keys_set:nn`, and seven
+`.tl_set_e:N` properties. This preserves the original `.estore in` expansion
+semantics and existing `\TmpValue...` scratch macros. The public
+`\InsertFigure` name, `[2][\empty]` signature, key names, fixed `[H]` placement,
+caption/label rendering, and deliberately inactive `pos`/`align` compatibility
+keys are unchanged.
+
 ### Retained: explicit `xparse`
 
 The LaTeX kernel provides modern document-command interfaces, but it deliberately
@@ -62,11 +76,13 @@ cover, chapter, float, bibliography, font, theorem, oral, and style behavior.
 They do not form one bounded state machine. Each future conversion needs its own
 fixture and visible-output proof; a mechanical global rewrite is rejected.
 
-### Deferred: `pgfkeys` to `l3keys`
+### Deferred: remaining `pgfkeys` families
 
-The seven key families expose different defaulting, storage, repeated-setup, and
-unknown-key behaviors. Migrating one family is justified only after freezing its
-complete parse and error contract. This slice does not change key parsing.
+Only the single-figure family moved. The remaining 55 literal
+`\pgfkeys`/`\pgfkeysvalueof` references span six files and expose different
+defaulting, storage, repeated-setup, rendering, and unknown-key behavior. No
+table, multi-figure, bibliography, theorem, font, or numbering key family is
+approved for conversion without its own frozen contract and output proof.
 
 ### Retained: `etoolbox`
 
@@ -114,11 +130,32 @@ The local source delta is seven fewer `\ifthenelse` calls in
 `cmd-numbering.tex` (15 to 8), one new bounded `expl3` string case, no public API
 change, and no PDF-output change.
 
+### Follow-up `l3keys` validation result
+
+The single-figure parser replacement passed:
+
+- the existing custom-value float contract plus new default, macro-expansion,
+  reset-on-repeat, and unknown-key hard-error contracts;
+- focused one-page text, normalized bounding-box, font-table, and 200-DPI raster
+  identity against the same fixture running the original `pgfkeys` parser;
+- fresh exact-HEAD `just ci`, including the V1 API, unchanged-project migration,
+  diagnostics, negative-key, student archive, float, theorem, font/CJK,
+  student-mode, watermark, and custom-style gates;
+- canonical 271-page A4 text, normalized bounding-box, and font-table identity;
+- identical 120-DPI raster output for all 271 canonical pages;
+- successful `just release review` package generation and verification;
+- a repo-external build of the generated student ZIP using the documented
+  `latexmk -xelatex -synctex=1 -interaction=nonstopmode thesis.tex` command,
+  producing 271 A4 pages, SyncTeX, and resolved references.
+
+`pgfkeys` remains intentionally active because six other template files still
+use it and PGF/TikZ also remains part of the rendering stack. This slice claims
+one bounded family migration, not package removal.
+
 ## Next research slice
 
 Do not continue by count alone. Rank candidates by removable dependency cost,
-finite semantics, existing fixture coverage, and output risk. A small isolated
-`pgfkeys` family may be the next research target only after its default,
-macro-expansion, unknown-key, and repeated-setup contract is captured; otherwise
-prefer another finite `ifthen` dispatcher. Keep each slice independently
-revertible.
+finite semantics, existing fixture coverage, and output risk. Before another key
+family moves, capture its default, macro-expansion, unknown-key, repeated-setup,
+and rendering contract under the current implementation. Otherwise prefer
+another finite `ifthen` dispatcher. Keep every slice independently revertible.

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ check: thesis
     ! grep -Eiq 'undefined references|undefined citations|Rerun to get (cross-references|outlines) right' "{{ log }}"
 
 # Run the required build and focused regression test gate.
-test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-theorem-contract _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
+test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-theorem-contract _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
 
 # Internal compatibility gate for every explicitly declared v1 command/environment.
 [private]
@@ -170,6 +170,16 @@ _test-float-contract:
     pdftotext -layout "{{ build_dir }}/tests/float-contract.pdf" "{{ build_dir }}/tests/float-contract.txt"
     pdfimages -list "{{ build_dir }}/tests/float-contract.pdf" > "{{ build_dir }}/tests/float-contract.images"
     python3 scripts/test/check-float-contract.py "{{ build_dir }}/tests"
+
+# Unknown single-figure keys must remain deterministic hard errors.
+[private]
+_test-figure-key-unknown:
+    mkdir -p "{{ build_dir }}/tests"
+    rm -f "{{ build_dir }}/tests/figure-key-unknown."*
+    if (cd "{{ source_dir }}" && xelatex -interaction=nonstopmode -halt-on-error -output-directory=../"{{ build_dir }}/tests" -jobname=figure-key-unknown ../tests/figure-key-unknown.tex); then echo "unknown figure key unexpectedly compiled"; exit 1; fi
+    grep -Fq 'unsupported' "{{ build_dir }}/tests/figure-key-unknown.log"
+    ! grep -Fq 'NCKU-TEST-FAIL' "{{ build_dir }}/tests/figure-key-unknown.log"
+    @echo "Figure key unknown-option PASS: deterministic hard error"
 
 # Internal runtime contract for all 21 public theorem insertion helpers.
 [private]

--- a/scripts/test/check-float-contract.py
+++ b/scripts/test/check-float-contract.py
@@ -144,6 +144,22 @@ def main() -> None:
     require(r"\begin{figure}[H]" in figure_source, "single figure no longer forces H")
     require(r"\begin{figure}[H]" in figures_source, "multi figure no longer forces H")
     require(r"\begin{table}[H]" in table_source, "table no longer forces H")
+    require(
+        r"\keys_define:nn { ncku / insert-figure }" in figure_source,
+        "single-figure keys no longer use the bounded l3keys family",
+    )
+    require(
+        figure_source.count(".tl_set_e:N") == 7,
+        "single-figure l3keys family no longer has seven expanded-storage keys",
+    )
+    require(
+        "/InsertFigure/.is family" not in figure_source,
+        "legacy pgfkeys single-figure family was reintroduced",
+    )
+    require(
+        r"\NCKUPrivateSetInsertFigureKeys{#1}" in figure_source,
+        "single-figure command bypasses the private key parser",
+    )
     require(figure_source.count(r"\TmpValuePosition") == 1, "figure pos key became behaviorally active")
     require(figure_source.count(r"\TmpValueAlign") == 1, "figure align key became behaviorally active")
     require(figures_source.count(r"\TmpMIValueAlign") == 1, "multi-figure align key became behaviorally active")

--- a/scripts/test/check-float-contract.py
+++ b/scripts/test/check-float-contract.py
@@ -34,6 +34,9 @@ def main() -> None:
         "NCKU-FLOAT-TABLE-TOP-STATE:0.0/FloatTableTopCaption/ncku:float:table-top/top/3pt/1.2/0.5",
         "NCKU-FLOAT-TABLE-BOTTOM-STATE:0.4/FloatTableBottomCaption/ncku:float:table-bottom/bottom/2pt/0.8/0.3",
         "NCKU-FLOAT-TABLE-STAR-STATE:0.0/FloatTableStarTitle/ncku:float:table-star/top/0.2",
+        "NCKU-FIGURE-KEY-DEFAULTS:1.0/0///H//0.4",
+        "NCKU-FIGURE-KEY-EXPANDED:1.75/15/ExpandedCaption/ncku:expanded/ignored-pos/ignored-align/0.9",
+        "NCKU-FIGURE-KEY-RESET:1.0/0///H//0.4",
     )
     for marker in state_markers:
         require(marker in compact_log, f"missing key-state marker: {marker}")

--- a/scripts/test/check-numbering-contract.py
+++ b/scripts/test/check-numbering-contract.py
@@ -92,10 +92,26 @@ def main() -> None:
         source.count(r"\begin{comment}") == 0,
         "runtime-dead numbering comment blocks reappeared",
     )
+    dispatcher = source.split(r"\newcommand\AppendCounterStringToFormatString", 1)[1].split(
+        r"\newcommand\SetupTitleNumberFormatString", 1
+    )[0]
+    require(r"\str_case_e:nn" in dispatcher, "counter-style dispatch is not an expl3 string case")
+    require(r"\ifthenelse" not in dispatcher, "counter-style dispatch regained sequential ifthen tests")
+    for style in (
+        "ChiNum",
+        "Tiangan",
+        "Arabic",
+        "LowerRoman",
+        "UpperRoman",
+        "LowerAlph",
+        "UpperAlph",
+    ):
+        require(dispatcher.count(f"{{{style}}}") == 1, f"counter-style case changed: {style}")
 
     print(
         "Numbering contract PASS: default/custom general+appendix titles/getters, "
-        "dynamic counters, 7 styles, F/T/E idempotence, unknown/empty no-op, A4 single page"
+        "dynamic counters, 7-style expl3 dispatch, F/T/E idempotence, "
+        "unknown/empty no-op, A4 single page"
     )
 
 

--- a/tests/figure-key-unknown.tex
+++ b/tests/figure-key-unknown.tex
@@ -1,0 +1,8 @@
+% Negative contract: unknown single-figure keys must not be silently ignored.
+\input{./template/configure}
+
+\NCKUPrivateSetInsertFigureKeys{unsupported=value}
+
+\begin{document}
+\typeout{NCKU-TEST-FAIL: unknown single-figure key was ignored}
+\end{document}

--- a/tests/float-contract.tex
+++ b/tests/float-contract.tex
@@ -92,6 +92,31 @@
   }
 \typeout{NCKU-FLOAT-TABLE-STAR-STATE: \TmpValueScale/\TmpValueNomTitle/\TmpValueLabel/\TmpValuePosition/\TmpValueOpacity}
 
+% Freeze the single-figure parser independently of rendering: literal defaults,
+% expanded macro values, and reset-on-repeat behavior must survive a parser swap.
+\begingroup
+\NCKUPrivateSetInsertFigureKeys{\empty}
+\typeout{NCKU-FIGURE-KEY-DEFAULTS: \TmpValueScale/\TmpValueAngle/\TmpValueCaption/\TmpValueLabel/\TmpValuePosition/\TmpValueAlign/\TmpValueOpacity}
+\def\NCKUFigureScale{1.75}
+\def\NCKUFigureAngle{15}
+\def\NCKUFigureCaption{Expanded Caption}
+\def\NCKUFigureLabel{ncku:expanded}
+\def\NCKUFigurePosition{ignored-pos}
+\def\NCKUFigureAlign{ignored-align}
+\def\NCKUFigureOpacity{0.9}
+\NCKUPrivateSetInsertFigureKeys{%
+  scale=\NCKUFigureScale,
+  angle=\NCKUFigureAngle,
+  caption=\NCKUFigureCaption,
+  label=\NCKUFigureLabel,
+  pos=\NCKUFigurePosition,
+  align=\NCKUFigureAlign,
+  opacity=\NCKUFigureOpacity}
+\typeout{NCKU-FIGURE-KEY-EXPANDED: \TmpValueScale/\TmpValueAngle/\TmpValueCaption/\TmpValueLabel/\TmpValuePosition/\TmpValueAlign/\TmpValueOpacity}
+\NCKUPrivateSetInsertFigureKeys{\empty}
+\typeout{NCKU-FIGURE-KEY-RESET: \TmpValueScale/\TmpValueAngle/\TmpValueCaption/\TmpValueLabel/\TmpValuePosition/\TmpValueAlign/\TmpValueOpacity}
+\endgroup
+
 References: \ref{ncku:float:single}, \ref{ncku:float:multi},
 \ref{ncku:float:sub-a}, \ref{ncku:float:sub-b}, \ref{ncku:float:sub-c},
 \ref{ncku:float:table-top}, \ref{ncku:float:table-bottom}.

--- a/thesis/template/command/cmd-figure.tex
+++ b/thesis/template/command/cmd-figure.tex
@@ -68,11 +68,20 @@
   opacity/.estore in = \TmpValueOpacity,
 } % End of \pgfkeys{}
 
+% Keep key parsing behind one private seam so its defaults, expansion, and
+% unknown-key behavior can be regression-tested independently of rendering.
+\ExplSyntaxOn
+\cs_new_protected:Npn \ncku_insert_figure_keys_set:n #1
+  { \pgfkeys { /InsertFigure, default, #1 } }
+\cs_new_eq:NN \NCKUPrivateSetInsertFigureKeys
+  \ncku_insert_figure_keys_set:n
+\ExplSyntaxOff
+
 % Insert a single column image
 \newcommand{\InsertFigure}[2][\empty]
 {%
   % Parse the input
-  \pgfkeys{/InsertFigure, default, #1}%
+  \NCKUPrivateSetInsertFigureKeys{#1}%
   %
   \begin{figure}[H]%
   \NCKUPrivateDisplayFramedFloatContent{\TmpValueOpacity}{%

--- a/thesis/template/command/cmd-figure.tex
+++ b/thesis/template/command/cmd-figure.tex
@@ -46,33 +46,36 @@
 
 % -----------------------------------------------------------------
 
-\pgfkeys
-{
-  /InsertFigure/.is family, /InsertFigure,
-  default/.style =
-  {
-    scale = 1.0,
-    angle = 0,
-    caption = \empty,
-    label = \empty,
-    pos = {H},      % Useless, for backporting
-    align = \empty, % Useless, for backporting
-    opacity = 0.4,
-  },
-  scale/.estore in = \TmpValueScale,
-  angle/.estore in = \TmpValueAngle,
-  caption/.estore in = \TmpValueCaption,
-  label/.estore in = \TmpValueLabel,
-  pos/.estore in = \TmpValuePosition,   % Useless, for backporting
-  align/.estore in = \TmpValueAlign,    % Useless, for backporting
-  opacity/.estore in = \TmpValueOpacity,
-} % End of \pgfkeys{}
-
-% Keep key parsing behind one private seam so its defaults, expansion, and
-% unknown-key behavior can be regression-tested independently of rendering.
 \ExplSyntaxOn
+\keys_define:nn { ncku / insert-figure }
+  {
+    scale   .tl_set_e:N = \TmpValueScale,
+    angle   .tl_set_e:N = \TmpValueAngle,
+    caption .tl_set_e:N = \TmpValueCaption,
+    label   .tl_set_e:N = \TmpValueLabel,
+    pos     .tl_set_e:N = \TmpValuePosition,
+    align   .tl_set_e:N = \TmpValueAlign,
+    opacity .tl_set_e:N = \TmpValueOpacity,
+  }
+
+% Reset every value on each call, then apply the caller's overrides. The public
+% optional argument uses the literal token \empty when omitted, so skip that
+% sentinel instead of handing it to l3keys as a key name.
 \cs_new_protected:Npn \ncku_insert_figure_keys_set:n #1
-  { \pgfkeys { /InsertFigure, default, #1 } }
+  {
+    \keys_set:nn { ncku / insert-figure }
+      {
+        scale = 1.0,
+        angle = 0,
+        caption = \empty,
+        label = \empty,
+        pos = H,
+        align = \empty,
+        opacity = 0.4,
+      }
+    \tl_if_eq:nnF {#1} {\empty}
+      { \keys_set:nn { ncku / insert-figure } {#1} }
+  }
 \cs_new_eq:NN \NCKUPrivateSetInsertFigureKeys
   \ncku_insert_figure_keys_set:n
 \ExplSyntaxOff

--- a/thesis/template/command/cmd-numbering.tex
+++ b/thesis/template/command/cmd-numbering.tex
@@ -113,24 +113,31 @@
 } % End of \newcommand{}
 \makeatother
 
-% Append counter value in style to string
+% Append counter value in style to string. The selected style can arrive through
+% a pgf-stored macro, so use the expanding string-case form. Unknown or empty
+% styles deliberately remain no-ops, matching the public compatibility contract.
+\ExplSyntaxOn
 \newcommand\AppendCounterStringToFormatString[3]
-{%
-  \ifthenelse{\equal{#2}{ChiNum}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\zhnum}{#3}}{}%
-  \ifthenelse{\equal{#2}{Tiangan}}{%
-    \NCKUPrivateAppendCounterValueFormatter{#1}{\zhtiangan}{#3}}{}%
-  \ifthenelse{\equal{#2}{Arabic}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\arabic}{#3}}{}%
-  \ifthenelse{\equal{#2}{LowerRoman}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\roman}{#3}}{}%
-  \ifthenelse{\equal{#2}{UpperRoman}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\Roman}{#3}}{}%
-  \ifthenelse{\equal{#2}{LowerAlph}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\alph}{#3}}{}%
-  \ifthenelse{\equal{#2}{UpperAlph}}{%
-    \NCKUPrivateAppendCounterFormatter{#1}{\Alph}{#3}}{}%
+{
+  \str_case_e:nn {#2}
+  {
+    {ChiNum}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\zhnum}{#3}}
+    {Tiangan}
+      {\NCKUPrivateAppendCounterValueFormatter{#1}{\zhtiangan}{#3}}
+    {Arabic}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\arabic}{#3}}
+    {LowerRoman}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\roman}{#3}}
+    {UpperRoman}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\Roman}{#3}}
+    {LowerAlph}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\alph}{#3}}
+    {UpperAlph}
+      {\NCKUPrivateAppendCounterFormatter{#1}{\Alph}{#3}}
+  }
 } % End of \newcommand{}
+\ExplSyntaxOff
 
 \newcommand\SetupTitleNumberFormatString[3]
 {%


### PR DESCRIPTION
## Intent

Migrate only the seven-key single-figure option parser from legacy `pgfkeys` to the LaTeX3 `l3keys` layer after first freezing the current parser contract. Keep every public API and rendered page unchanged.

## Stack

This PR is intentionally based on `feat/expl3-numbering-dispatch` and depends on #80. Its diff relative to that branch is one independently revertible follow-up slice. It should be reviewed/merged only after #80; it is not a request to merge either PR automatically.

## Scope

- add one private parser seam while the original `pgfkeys` implementation is still active;
- freeze literal defaults, expanded macro-valued storage, reset-on-repeat behavior, and unknown-key hard-error behavior;
- replace only `/InsertFigure` with `\keys_define:nn`, `\keys_set:nn`, and seven `.tl_set_e:N` properties;
- retain the public `\InsertFigure` name and `[2][\empty]` signature;
- retain all seven key names, existing `\TmpValue...` scratch macros, fixed `[H]` placement, caption/label behavior, and inactive `pos`/`align` compatibility keys;
- add a negative unknown-key fixture and source-boundary assertions;
- record the accepted bounded migration and validation evidence.

## Compatibility boundary

Unchanged:

- XeLaTeX, root `thesis.tex`, TeX Live/Overleaf workflow;
- all V1 and V2 public command signatures;
- `scale`, `angle`, `caption`, `label`, `pos`, `align`, and `opacity` names/defaults;
- `.estore in`-equivalent full expansion through `.tl_set_e:N`;
- unknown-key failure rather than silent acceptance;
- figure rendering, fonts, geometry, page count, positions, and package graph.

`pgfkeys` intentionally remains active: 55 literal references remain across six other template files, and PGF/TikZ remains in the rendering stack. This PR does not claim package removal or approve migration of any other key family.

## Validation

Exact local head: `3921c539508acca52b7acda4b30c21f74e3b79e5`

- original `pgfkeys` parser contract baseline: PASS;
- `l3keys` defaults / macro expansion / reset / unknown-key hard error: PASS;
- focused float text: identical;
- focused normalized bounding boxes: identical;
- focused font table: identical;
- focused 200-DPI raster: identical;
- fresh exact-HEAD `just ci`: PASS;
- V1 API and unchanged-project migration: PASS;
- diagnostics and all focused regression gates: PASS;
- canonical PDF: 271 A4 pages;
- canonical text / normalized bounding boxes / fonts: identical;
- canonical 120-DPI rasters: **271/271 byte-identical**;
- `just release review`: PASS;
- generated student ZIP exact-tree verification: PASS;
- repo-external documented `latexmk -xelatex -synctex=1 -interaction=nonstopmode thesis.tex` build: PASS, 271 A4 pages with SyncTeX and resolved references.

## Out of scope

- no table, multi-figure, bibliography, theorem, font, or numbering key migration;
- no package removal;
- no class migration, engine change, tagged-PDF work, release, or Overleaf update;
- no merge requested by this PR creation.
