### PR TITLE
refactor: migrate custom font filename keys to l3keys

### DIFF
--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -25,7 +25,7 @@ student project shape, and complete audited 1.x public API through the 2.x line.
 - [`full-review-repairs.md`](full-review-repairs.md)
 - [`super-optimization.md`](super-optimization.md)
 - [`expl3-internals.md`](expl3-internals.md) — bounded post-release internal
-  modernization with five output-neutral implementation slices.
+  modernization with six output-neutral implementation slices.
 - [`pgfkeys-replacement-landscape-2026-07.md`](pgfkeys-replacement-landscape-2026-07.md)
   — dated official-source comparison of `l3keys`, kernel key options,
   `expkv-bundle`, retained PGF/TikZ `pgfkeys`, and deprecated `l3keys2e`.

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,6 +1,6 @@
 # Incremental `expl3` Internal Modernization
 
-Status: first five bounded slices implemented and validated; pending review
+Status: first six bounded slices implemented and validated; pending review
 
 ## Intent
 
@@ -112,6 +112,27 @@ This command-level parser uses `l3keys` directly. It does not use or require
 kernel `\DeclareKeys`, `\ProcessKeyOptions`, and `\SetKeys` surface when that
 becomes relevant.
 
+### Selected follow-up: custom-font filename key parsing
+
+The four-key `/ParseCustomFontFiles` family was selected separately from the
+font-loading `/ParseFontOption` family. Before replacement, a private seam and
+focused fixture froze empty defaults, expanded macro-valued filenames, both
+English and Chinese public setter routes, custom-type selection, repeated calls,
+and unknown-key hard errors.
+
+The legacy public filename macros deliberately retain references to the four
+shared scratch values rather than snapshots. Consequently, a later partial,
+Chinese, or omitted setter call can change values previously exposed through an
+English setter. This surprising alias behavior is preserved by this parser-only
+slice; correcting it requires a separate behavior-change intent and migration
+contract.
+
+The parser now uses `ncku / custom-font-files` with four `.tl_set_e:N` keys and
+explicit per-call scratch clearing. `\SetCustomEngFontFiles`,
+`\SetCustomChiFontFiles`, `\SetFontUseType`, every custom filename macro, and
+the font initialization/rendering path remain unchanged. `/ParseFontOption`
+continues to use `pgfkeys` and is outside this slice.
+
 ### Retained: explicit `xparse`
 
 The LaTeX kernel provides modern document-command interfaces, but it deliberately
@@ -128,12 +149,13 @@ fixture and visible-output proof; a mechanical global rewrite is rejected.
 
 ### Deferred: remaining `pgfkeys` families
 
-Only the single-figure, single-table, theorem-content, and reference-setup
-families moved. The remaining 46 literal `\pgfkeys`/`\pgfkeysvalueof`
+Only the single-figure, single-table, theorem-content, reference-setup, and
+custom-font filename families moved. The remaining 42 literal
+`\pgfkeys`/`\pgfkeysvalueof`
 references span four files and expose different defaulting, storage,
 repeated-setup, rendering, and unknown-key behavior. No multi-figure, dynamic
-theorem-format, font, or numbering key family is approved for conversion
-without its own frozen contract and output proof.
+theorem-format, remaining font-loading, or numbering key family is approved for
+conversion without its own frozen contract and output proof.
 
 ### Retained: `etoolbox`
 
@@ -275,10 +297,38 @@ After the four key-family slices, 46 literal `pgfkeys` references remain across
 four active template files. PGF/TikZ still loads `pgfkeys` at runtime, so no
 package-removal claim is made.
 
+### Custom-font filename `l3keys` validation result
+
+The custom-font filename parser replacement passed:
+
+- original-implementation empty defaults, macro expansion, custom-type
+  selection, both public setter routes, repeated calls, shared-scratch alias
+  behavior, and unknown-key hard-error contracts;
+- focused one-page text, bounding-box XML, font-table, and 200-DPI raster
+  identity against the same fixture using the original `pgfkeys` parser;
+- fresh exact-HEAD `just ci`, including V1 API, unchanged-project migration,
+  diagnostics, all negative-key gates, student archive, float, theorem matrix,
+  font/CJK, student-mode, watermark, and custom-style gates;
+- canonical 271-page A4 text, 40,823 normalized bounding-box words, and
+  font-table identity;
+- identical 120-DPI raster output for all 271 canonical pages;
+- successful `just release review` package generation and verification;
+- a repo-external `latexmk -xelatex -synctex=1` build of the generated student
+  ZIP, producing 271 A4 pages, SyncTeX, and resolved references;
+- zero `l3keys2e` references in active student source and zero `l3keys2e`
+  runtime loads across generated `.fls` files.
+
+After the five key-family slices, 42 literal `pgfkeys` references remain across
+four active template files. The separate `/ParseFontOption` font-loading family
+and all other deferred families remain unchanged.
+
 ## Next research slice
 
 Do not continue by count alone. Rank candidates by removable dependency cost,
 finite semantics, existing fixture coverage, and output risk. Before another key
 family moves, capture its default, macro-expansion, unknown-key, repeated-setup,
 and rendering contract under the current implementation. Otherwise prefer
-another finite `ifthen` dispatcher. Keep every slice independently revertible.
+another finite `ifthen` dispatcher. `/ParseFontOption` is the adjacent candidate,
+but it must remain separate because it directly configures `fontspec` and
+`xeCJK`; require explicit English/CJK optional-face and font-table coverage
+before considering implementation. Keep every slice independently revertible.

--- a/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
+++ b/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
@@ -104,9 +104,10 @@ legacy key package is churn, not modernization.
 
 ## NCKU-specific evidence and judgement
 
-1. Four isolated command families now use `l3keys`: single figure, single table,
-   theorem content, and reference setup. Each migration first froze the legacy
-   parser contract and then proved canonical output identity.
+1. Five isolated command families now use `l3keys`: single figure, single table,
+   theorem content, reference setup, and custom-font filename parsing. Each
+   migration first froze the legacy parser contract and then proved canonical
+   output identity.
 2. `SetupReference` preserves its default/custom/repeated setup, rendered BibTeX
    output, unknown-key failure, and `apacite[notocbib]` preamble side effect.
 3. Active student source contains zero `l3keys2e` references, and generated
@@ -116,7 +117,7 @@ legacy key package is churn, not modernization.
    scratch state and all row-dispatch routes are covered.
 5. Keep dynamic theorem-format/counter families deferred; they are not the same
    state machine as theorem-content `title`/`label` parsing.
-6. Do not claim package removal while 46 direct `pgfkeys`/`pgfkeysvalueof`
+6. Do not claim package removal while 42 direct `pgfkeys`/`pgfkeysvalueof`
    references remain across four files or while PGF/TikZ keeps `pgfkeys` active
    transitively.
 7. Continue requiring focused semantic checks, full text/normalized bbox/fonts,
@@ -124,7 +125,7 @@ legacy key package is churn, not modernization.
    student ZIP direct build, and exact-SHA hosted checks.
 
 For this repository, `l3keys` is the best-fit default because it is official,
-current, already loaded, and has passed four independently reversible,
+current, already loaded, and has passed five independently reversible,
 output-neutral family migrations. `expkv-bundle` is a credible modern
 alternative, but it solves a more specialized expandability and cross-format
 problem that NCKU has not demonstrated. `pgfkeys` should be reduced where it is

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ check: thesis
     ! grep -Eiq 'undefined references|undefined citations|Rerun to get (cross-references|outlines) right' "{{ log }}"
 
 # Run the required build and focused regression test gate.
-test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
+test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
 
 # Internal compatibility gate for every explicitly declared v1 command/environment.
 [private]
@@ -330,6 +330,26 @@ _test-metadata-bookmark:
     ! grep -Eiq 'Token not allowed in a PDF string|already defined|destination with the same identifier' "{{ build_dir }}/tests/metadata-bookmark.log"
     pdfinfo "{{ build_dir }}/tests/metadata-bookmark.pdf" > "{{ build_dir }}/tests/metadata-bookmark.pdfinfo"
     grep -Fq 'Title:           NCKU Metadata Line (成大中繼資料標題)' "{{ build_dir }}/tests/metadata-bookmark.pdfinfo"
+
+# Internal contract for custom-font filename key parsing and shared aliases.
+[private]
+_test-custom-font-files-contract:
+    mkdir -p "{{ build_dir }}/tests"
+    rm -f "{{ build_dir }}/tests/custom-font-files-contract."*
+    cd "{{ source_dir }}" && xelatex -interaction=nonstopmode -halt-on-error -output-directory=../"{{ build_dir }}/tests" -jobname=custom-font-files-contract ../tests/custom-font-files-contract.tex
+    pdfinfo "{{ build_dir }}/tests/custom-font-files-contract.pdf" > "{{ build_dir }}/tests/custom-font-files-contract.pdfinfo"
+    pdftotext -layout "{{ build_dir }}/tests/custom-font-files-contract.pdf" "{{ build_dir }}/tests/custom-font-files-contract.txt"
+    python3 scripts/test/check-custom-font-files-contract.py "{{ build_dir }}/tests"
+
+# Unknown custom-font filename keys remain deterministic hard errors.
+[private]
+_test-custom-font-files-key-unknown:
+    mkdir -p "{{ build_dir }}/tests"
+    rm -f "{{ build_dir }}/tests/custom-font-files-key-unknown."*
+    if (cd "{{ source_dir }}" && xelatex -interaction=nonstopmode -halt-on-error -output-directory=../"{{ build_dir }}/tests" -jobname=custom-font-files-key-unknown ../tests/custom-font-files-key-unknown.tex); then echo "unknown custom-font key unexpectedly compiled"; exit 1; fi
+    grep -Fq 'unsupported' "{{ build_dir }}/tests/custom-font-files-key-unknown.log"
+    ! grep -Fq 'NCKU-TEST-FAIL' "{{ build_dir }}/tests/custom-font-files-key-unknown.log"
+    @echo "Custom font filename key unknown-option PASS: deterministic hard error"
 
 # Internal regression test for bundled Latin/CJK font policy.
 [private]

--- a/scripts/test/check-custom-font-files-contract.py
+++ b/scripts/test/check-custom-font-files-contract.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Verify custom-font filename parser state and its bounded source contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def normalized(text: str) -> str:
+    return re.sub(r"\s+", "", text)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("build_dir", type=Path)
+args = parser.parse_args()
+
+root = Path(__file__).resolve().parents[2]
+source_path = root / "thesis/template/command/cmd-font.tex"
+source = source_path.read_text(errors="replace")
+log = (args.build_dir / "custom-font-files-contract.log").read_text(errors="replace")
+text = (args.build_dir / "custom-font-files-contract.txt").read_text(errors="replace")
+pdfinfo = (args.build_dir / "custom-font-files-contract.pdfinfo").read_text(errors="replace")
+compact = normalized(log)
+
+markers = [
+    "NCKU-CFONT-INITIAL-ENG:times.ttf|timesi.ttf|timesbd.ttf|timesbi.ttf",
+    "NCKU-CFONT-INITIAL-CHI:kaiu.ttf|||",
+    "NCKU-CFONT-SCRATCH-ONE:scratch-normal.ttf|||",
+    "NCKU-CFONT-SCRATCH-RESET:|||",
+    "NCKU-CFONT-OMITTED-TYPE:10",
+    "NCKU-CFONT-OMITTED-ENG:times.ttf|timesi.ttf|timesbd.ttf|timesbi.ttf",
+    "NCKU-CFONT-ENG-EXPANDED:eng-normal-a.ttf|eng-italic-a.ttf|eng-bold-a.ttf|eng-bi-a.ttf",
+    "NCKU-CFONT-ENG-PARTIAL-ALIAS:||eng-bold-b.ttf|",
+    "NCKU-CFONT-ENG-AFTER-CHI:chi-normal.ttf|chi-italic.ttf|chi-bold.ttf|chi-bi.ttf",
+    "NCKU-CFONT-CHI-FULL:chi-normal.ttf|chi-italic.ttf|chi-bold.ttf|chi-bi.ttf",
+    "NCKU-CFONT-ALIASES-AFTER-OMITTED:|||/|||",
+    "NCKU-TEST-PASS:customfontfilenameparsercontract",
+]
+for marker in markers:
+    require(normalized(marker) in compact, f"missing custom-font marker: {marker}")
+
+require("NCKU-TEST-FAIL" not in log, "custom-font contract emitted failure marker")
+require("Custom font filename parser contract." in text, "focused PDF text missing")
+require(re.search(r"^Pages:\s+1$", pdfinfo, re.MULTILINE) is not None, "focused PDF is not one page")
+require(re.search(r"^Page size:.*A4", pdfinfo, re.MULTILINE) is not None, "focused PDF is not A4")
+
+require(
+    r"\newcommand{\NCKUPrivateSetCustomFontFileKeys}[1]" in source,
+    "custom-font private parser seam is missing",
+)
+require(
+    source.count(r"\NCKUPrivateSetCustomFontFileKeys{#1}") == 2,
+    "public custom-font setters do not both route through the private seam",
+)
+require(
+    r"/ParseCustomFontFiles/.is family" in source,
+    "legacy custom-font pgfkeys family is missing before migration",
+)
+require("l3keys2e" not in source, "custom-font source must not use l3keys2e")
+
+print("Custom font filename contract PASS: defaults, expansion, aliases, routes, and source boundary")

--- a/scripts/test/check-custom-font-files-contract.py
+++ b/scripts/test/check-custom-font-files-contract.py
@@ -52,7 +52,7 @@ require(re.search(r"^Pages:\s+1$", pdfinfo, re.MULTILINE) is not None, "focused 
 require(re.search(r"^Page size:.*A4", pdfinfo, re.MULTILINE) is not None, "focused PDF is not A4")
 
 require(
-    r"\newcommand{\NCKUPrivateSetCustomFontFileKeys}[1]" in source,
+    r"\cs_new_protected:Npn \NCKUPrivateSetCustomFontFileKeys #1" in source,
     "custom-font private parser seam is missing",
 )
 require(
@@ -60,9 +60,25 @@ require(
     "public custom-font setters do not both route through the private seam",
 )
 require(
-    r"/ParseCustomFontFiles/.is family" in source,
-    "legacy custom-font pgfkeys family is missing before migration",
+    r"\keys_define:nn { ncku / custom-font-files }" in source,
+    "custom-font l3keys family is missing",
+)
+require(
+    r"\keys_set:nn { ncku / custom-font-files } {#1}" in source,
+    "custom-font private seam does not route through l3keys",
+)
+require(
+    source.count(".tl_set_e:N") == 4,
+    "custom-font parser must preserve expanded storage for exactly four keys",
+)
+require(
+    r"/ParseCustomFontFiles/.is family" not in source,
+    "legacy custom-font pgfkeys family remains after migration",
+)
+require(
+    r"/ParseFontOption/.is family" in source,
+    "unrelated font-loading pgfkeys family changed in this slice",
 )
 require("l3keys2e" not in source, "custom-font source must not use l3keys2e")
 
-print("Custom font filename contract PASS: defaults, expansion, aliases, routes, and source boundary")
+print("Custom font filename contract PASS: l3keys defaults, expansion, aliases, routes, and source boundary")

--- a/tests/custom-font-files-contract.tex
+++ b/tests/custom-font-files-contract.tex
@@ -1,0 +1,44 @@
+% Focused contract for the legacy custom-font filename parser.
+\input{./template/configure}
+
+\typeout{NCKU-CFONT-INITIAL-ENG: \VarFontTypeCustomEngFileNameNormal|\VarFontTypeCustomEngFileNameItalic|\VarFontTypeCustomEngFileNameBold|\VarFontTypeCustomEngFileNameBoldItalic}
+\typeout{NCKU-CFONT-INITIAL-CHI: \VarFontTypeCustomChiFileNameNormal|\VarFontTypeCustomChiFileNameItalic|\VarFontTypeCustomChiFileNameBold|\VarFontTypeCustomChiFileNameBoldItalic}
+
+% The private parser resets all four shared scratch values on every call.
+\NCKUPrivateSetCustomFontFileKeys{NormalFont=scratch-normal.ttf}
+\typeout{NCKU-CFONT-SCRATCH-ONE: \TmpValueNormalFont|\TmpValueItalicFont|\TmpValueBoldFont|\TmpValueBoldItalicFont}
+\NCKUPrivateSetCustomFontFileKeys{}
+\typeout{NCKU-CFONT-SCRATCH-RESET: \TmpValueNormalFont|\TmpValueItalicFont|\TmpValueBoldFont|\TmpValueBoldItalicFont}
+
+% Omitted public input selects the custom type without changing untouched static defaults.
+\SetFontUseType{\VarFontTypeTimesKaiu}
+\SetCustomEngFontFiles
+\typeout{NCKU-CFONT-OMITTED-TYPE: \GetFontUseType}
+\typeout{NCKU-CFONT-OMITTED-ENG: \VarFontTypeCustomEngFileNameNormal|\VarFontTypeCustomEngFileNameItalic|\VarFontTypeCustomEngFileNameBold|\VarFontTypeCustomEngFileNameBoldItalic}
+
+% pgfkeys .estore-in expands macro-valued filenames before shared scratch storage.
+\def\NCKUCustomNormal{eng-normal-a.ttf}
+\def\NCKUCustomItalic{eng-italic-a.ttf}
+\def\NCKUCustomBold{eng-bold-a.ttf}
+\def\NCKUCustomBoldItalic{eng-bi-a.ttf}
+\SetCustomEngFontFiles[NormalFont=\NCKUCustomNormal,ItalicFont=\NCKUCustomItalic,BoldFont=\NCKUCustomBold,BoldItalicFont=\NCKUCustomBoldItalic]
+\def\NCKUCustomNormal{changed-normal.ttf}
+\def\NCKUCustomItalic{changed-italic.ttf}
+\def\NCKUCustomBold{changed-bold.ttf}
+\def\NCKUCustomBoldItalic{changed-bi.ttf}
+\typeout{NCKU-CFONT-ENG-EXPANDED: \VarFontTypeCustomEngFileNameNormal|\VarFontTypeCustomEngFileNameItalic|\VarFontTypeCustomEngFileNameBold|\VarFontTypeCustomEngFileNameBoldItalic}
+
+% Preserve the legacy alias contract: public filename macros retain references
+% to the shared scratch values rather than snapshots of each setter call.
+\SetCustomEngFontFiles[BoldFont=eng-bold-b.ttf]
+\typeout{NCKU-CFONT-ENG-PARTIAL-ALIAS: \VarFontTypeCustomEngFileNameNormal|\VarFontTypeCustomEngFileNameItalic|\VarFontTypeCustomEngFileNameBold|\VarFontTypeCustomEngFileNameBoldItalic}
+\SetCustomChiFontFiles[NormalFont=chi-normal.ttf,ItalicFont=chi-italic.ttf,BoldFont=chi-bold.ttf,BoldItalicFont=chi-bi.ttf]
+\typeout{NCKU-CFONT-ENG-AFTER-CHI: \VarFontTypeCustomEngFileNameNormal|\VarFontTypeCustomEngFileNameItalic|\VarFontTypeCustomEngFileNameBold|\VarFontTypeCustomEngFileNameBoldItalic}
+\typeout{NCKU-CFONT-CHI-FULL: \VarFontTypeCustomChiFileNameNormal|\VarFontTypeCustomChiFileNameItalic|\VarFontTypeCustomChiFileNameBold|\VarFontTypeCustomChiFileNameBoldItalic}
+\SetCustomChiFontFiles
+\typeout{NCKU-CFONT-ALIASES-AFTER-OMITTED: \VarFontTypeCustomEngFileNameNormal|\VarFontTypeCustomEngFileNameItalic|\VarFontTypeCustomEngFileNameBold|\VarFontTypeCustomEngFileNameBoldItalic/\VarFontTypeCustomChiFileNameNormal|\VarFontTypeCustomChiFileNameItalic|\VarFontTypeCustomChiFileNameBold|\VarFontTypeCustomChiFileNameBoldItalic}
+
+\begin{document}
+Custom font filename parser contract.
+\typeout{NCKU-TEST-PASS: custom font filename parser contract}
+\end{document}

--- a/tests/custom-font-files-key-unknown.tex
+++ b/tests/custom-font-files-key-unknown.tex
@@ -1,0 +1,8 @@
+% Negative contract: unknown custom-font filename keys must fail.
+\input{./template/configure}
+
+\NCKUPrivateSetCustomFontFileKeys{unsupported=value}
+
+\begin{document}
+\typeout{NCKU-TEST-FAIL: unknown custom font key was ignored}
+\end{document}

--- a/thesis/template/command/cmd-font.tex
+++ b/thesis/template/command/cmd-font.tex
@@ -62,28 +62,30 @@
 \def \VarFontTypeCustomChiFileNameBold {} % Default
 \def \VarFontTypeCustomChiFileNameBoldItalic {} % Default
 
-\pgfkeys
-{
-  /ParseCustomFontFiles/.is family, /ParseCustomFontFiles,
-  default/.style =
+\ExplSyntaxOn
+\keys_define:nn { ncku / custom-font-files }
   {
-    NormalFont = \empty,
-    ItalicFont = \empty,
-    BoldFont = \empty,
-    BoldItalicFont = \empty,
-  },
-  NormalFont/.estore in = \TmpValueNormalFont,
-  ItalicFont/.estore in = \TmpValueItalicFont,
-  BoldFont/.estore in = \TmpValueBoldFont,
-  BoldItalicFont/.estore in = \TmpValueBoldItalicFont,
-} % End of \pgfkeys{}
+    NormalFont     .tl_set_e:N = \TmpValueNormalFont,
+    ItalicFont     .tl_set_e:N = \TmpValueItalicFont,
+    BoldFont       .tl_set_e:N = \TmpValueBoldFont,
+    BoldItalicFont .tl_set_e:N = \TmpValueBoldItalicFont,
+  }
 
-% Keep custom-font filename parsing behind one private seam so its legacy
-% defaults, expansion, shared-scratch aliases, and errors can be frozen first.
-\newcommand{\NCKUPrivateSetCustomFontFileKeys}[1]
-{%
-  \pgfkeys{/ParseCustomFontFiles, default, #1}%
-} % End of \newcommand{}
+\cs_new_protected:Npn \ncku_custom_font_files_set_keys:n #1
+  {
+    \tl_clear:N \TmpValueNormalFont
+    \tl_clear:N \TmpValueItalicFont
+    \tl_clear:N \TmpValueBoldFont
+    \tl_clear:N \TmpValueBoldItalicFont
+    \tl_if_eq:nnF {#1} { \empty }
+      { \keys_set:nn { ncku / custom-font-files } {#1} }
+  }
+
+% Keep custom-font filename parsing behind one private seam. Public filename
+% macros deliberately retain the legacy shared-scratch alias behavior.
+\cs_new_protected:Npn \NCKUPrivateSetCustomFontFileKeys #1
+  { \ncku_custom_font_files_set_keys:n {#1} }
+\ExplSyntaxOff
 
 \newcommand{\SetCustomEngFontFiles}[1][\empty]
 {%

--- a/thesis/template/command/cmd-font.tex
+++ b/thesis/template/command/cmd-font.tex
@@ -78,12 +78,19 @@
   BoldItalicFont/.estore in = \TmpValueBoldItalicFont,
 } % End of \pgfkeys{}
 
+% Keep custom-font filename parsing behind one private seam so its legacy
+% defaults, expansion, shared-scratch aliases, and errors can be frozen first.
+\newcommand{\NCKUPrivateSetCustomFontFileKeys}[1]
+{%
+  \pgfkeys{/ParseCustomFontFiles, default, #1}%
+} % End of \newcommand{}
+
 \newcommand{\SetCustomEngFontFiles}[1][\empty]
 {%
   \SetFontUseType{\VarFontTypeCustom}
   %
   % Parse the input
-  \pgfkeys{/ParseCustomFontFiles, default, #1}%
+  \NCKUPrivateSetCustomFontFileKeys{#1}%
   %
   \ifthenelse{\equal{\TmpValueNormalFont}{\empty}}{}{%
     \renewcommand{\VarFontTypeCustomEngFileNameNormal}{%
@@ -104,7 +111,7 @@
   \SetFontUseType{\VarFontTypeCustom}
   %
   % Parse the input
-  \pgfkeys{/ParseCustomFontFiles, default, #1}%
+  \NCKUPrivateSetCustomFontFileKeys{#1}%
   %
   \ifthenelse{\equal{\TmpValueNormalFont}{\empty}}{}{%
     \renewcommand{\VarFontTypeCustomChiFileNameNormal}{%


### PR DESCRIPTION
## Summary

- freeze the legacy `/ParseCustomFontFiles` contract behind one private seam
- migrate only that four-key custom-font filename parser from `pgfkeys` to `l3keys`
- preserve both public setters, expanded macro-valued storage, custom-type selection, unknown-key failure, and the existing shared-scratch alias behavior
- keep `/ParseFontOption`, font loading/rendering, multi-figure, numbering, and theorem registries unchanged
- add positive and negative focused tests and update the modernization/research inventory

## Important compatibility note

The public custom-font filename macros currently retain references to shared scratch values rather than independent snapshots. Later partial, Chinese, or omitted setter calls can therefore change values exposed by earlier English setter calls. This PR deliberately preserves that observed legacy behavior because it is a parser-only migration. Any correction should be a separate behavior-change PR with its own migration contract.

## Validation

- legacy `pgfkeys` positive and unknown-key contracts passed before migration
- focused one-page text, bbox XML, font table, and 200-DPI raster: identical
- final exact-SHA `just ci`: pass
- canonical 271-page A4 text: identical
- canonical normalized bbox words: 40,823 identical
- canonical font table: identical
- canonical 120-DPI raster: 271/271 pages identical
- `just release review`: pass
- extracted student ZIP direct `latexmk -xelatex -synctex=1` build: 271 A4 pages, SyncTeX, resolved references
- active student `l3keys2e` source references: 0
- generated `.fls` `l3keys2e` runtime loads: 0
- remaining literal `pgfkeys`/`pgfkeysvalueof` references: 42 across four active template files

## Scope

Eight files only. No release, tag, branch cleanup, Overleaf update, or migration of `/ParseFontOption` is included.
