### PR TITLE
refactor: migrate font option keys to l3keys

### DIFF
--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -25,7 +25,7 @@ student project shape, and complete audited 1.x public API through the 2.x line.
 - [`full-review-repairs.md`](full-review-repairs.md)
 - [`super-optimization.md`](super-optimization.md)
 - [`expl3-internals.md`](expl3-internals.md) — bounded post-release internal
-  modernization with six output-neutral implementation slices.
+  modernization with seven output-neutral implementation slices.
 - [`pgfkeys-replacement-landscape-2026-07.md`](pgfkeys-replacement-landscape-2026-07.md)
   — dated official-source comparison of `l3keys`, kernel key options,
   `expkv-bundle`, retained PGF/TikZ `pgfkeys`, and deprecated `l3keys2e`.

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,6 +1,6 @@
 # Incremental `expl3` Internal Modernization
 
-Status: first six bounded slices implemented and validated; pending review
+Status: first seven bounded slices implemented and validated; pending review
 
 ## Intent
 
@@ -130,8 +130,23 @@ contract.
 The parser now uses `ncku / custom-font-files` with four `.tl_set_e:N` keys and
 explicit per-call scratch clearing. `\SetCustomEngFontFiles`,
 `\SetCustomChiFontFiles`, `\SetFontUseType`, every custom filename macro, and
-the font initialization/rendering path remain unchanged. `/ParseFontOption`
-continues to use `pgfkeys` and is outside this slice.
+the font initialization/rendering path remain unchanged. `/ParseFontOption` was
+outside that slice and moved only in the independently validated follow-up below.
+
+### Selected follow-up: font-option key parsing
+
+The four-key `/ParseFontOption` family directly feeds `fontspec` and `xeCJK`, so
+it moved only after a separate private seam and focused loading fixture froze
+empty defaults, expanded macro-valued file names, repeated-call reset, unknown-key
+hard errors, and both public English and Chinese loading routes.
+
+The parser now uses `ncku / font-options` with four `.tl_set_e:N` keys and
+explicit per-call scratch clearing. The focused PDF embeds all four bundled Times
+faces through `\SetEngMainFont`; `\SetChiMainFont` embeds bundled KaiU with the
+existing fake-bold and fake-slant policy. Noto variables remain in source, but
+Noto font files are not bundled student-archive assets and were not invented as
+fixture dependencies. The public setter signatures and every downstream
+`fontspec`/`xeCJK` call remain unchanged.
 
 ### Retained: explicit `xparse`
 
@@ -149,12 +164,11 @@ fixture and visible-output proof; a mechanical global rewrite is rejected.
 
 ### Deferred: remaining `pgfkeys` families
 
-Only the single-figure, single-table, theorem-content, reference-setup, and
-custom-font filename families moved. The remaining 42 literal
-`\pgfkeys`/`\pgfkeysvalueof`
-references span four files and expose different defaulting, storage,
-repeated-setup, rendering, and unknown-key behavior. No multi-figure, dynamic
-theorem-format, remaining font-loading, or numbering key family is approved for
+Only the single-figure, single-table, theorem-content, reference-setup,
+custom-font filename, and font-option families moved. The remaining 38 literal
+`\pgfkeys`/`\pgfkeysvalueof` references span three files and expose different
+defaulting, storage, repeated-setup, rendering, and unknown-key behavior. No
+multi-figure, dynamic theorem-format, or numbering key family is approved for
 conversion without its own frozen contract and output proof.
 
 ### Retained: `etoolbox`
@@ -322,13 +336,38 @@ After the five key-family slices, 42 literal `pgfkeys` references remain across
 four active template files. The separate `/ParseFontOption` font-loading family
 and all other deferred families remain unchanged.
 
+### Font-option `l3keys` validation result
+
+The font-option parser replacement passed:
+
+- original-implementation empty defaults, macro expansion, repeated reset,
+  unknown-key hard-error, and both public loading-route contracts;
+- real bundled-font rendering for Times normal/italic/bold/bold-italic and KaiU
+  normal/fake-bold/fake-slant/fake-bold-slant, with exact `pdffonts` identity;
+- focused one-page text, bounding-box XML, font-table, and 200-DPI raster
+  identity against the same fixture using the original `pgfkeys` parser;
+- fresh exact-HEAD `just ci`, including the adjacent custom-font filename family
+  and both negative-key gates;
+- canonical 271-page A4 text, 40,823 normalized bounding-box words, and
+  font-table identity;
+- identical 120-DPI raster output for all 271 canonical pages;
+- successful `just release review` package generation and verification;
+- a repo-external `latexmk -xelatex -synctex=1` build of the generated student
+  ZIP, producing 271 A4 pages, SyncTeX, and resolved references;
+- zero `l3keys2e` references in active student source and zero `l3keys2e`
+  runtime loads across generated `.fls` files.
+
+After the six key-family slices, 38 literal `pgfkeys` references remain across
+three active template files. `cmd-font.tex` now has no direct `pgfkeys`
+references; PGF/TikZ still loads the package transitively.
+
 ## Next research slice
 
 Do not continue by count alone. Rank candidates by removable dependency cost,
 finite semantics, existing fixture coverage, and output risk. Before another key
 family moves, capture its default, macro-expansion, unknown-key, repeated-setup,
-and rendering contract under the current implementation. Otherwise prefer
-another finite `ifthen` dispatcher. `/ParseFontOption` is the adjacent candidate,
-but it must remain separate because it directly configures `fontspec` and
-`xeCJK`; require explicit English/CJK optional-face and font-table coverage
-before considering implementation. Keep every slice independently revertible.
+and rendering contract under the current implementation. The remaining choices
+are coupled multi-figure parsing, dynamic theorem registration, and numbering
+families; none is approved automatically by reference count. Prefer the smallest
+finite dispatcher or add missing contracts first, and keep every slice
+independently revertible.

--- a/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
+++ b/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
@@ -104,23 +104,26 @@ legacy key package is churn, not modernization.
 
 ## NCKU-specific evidence and judgement
 
-1. Five isolated command families now use `l3keys`: single figure, single table,
-   theorem content, reference setup, and custom-font filename parsing. Each
-   migration first froze the legacy parser contract and then proved canonical
-   output identity.
+1. Six isolated command families now use `l3keys`: single figure, single table,
+   theorem content, reference setup, custom-font filename parsing, and font-option
+   parsing. Each migration first froze the legacy parser contract and then proved
+   canonical output identity.
 2. `SetupReference` preserves its default/custom/repeated setup, rendered BibTeX
    output, unknown-key failure, and `apacite[notocbib]` preamble side effect.
 3. Active student source contains zero `l3keys2e` references, and generated
    runtime `.fls` files contain zero `l3keys2e` loads. The command-level parsers
    use `l3keys` directly and do not need the deprecated option bridge.
-4. Keep the top-level/nested multi-figure parser deferred until both shared
+4. The font-option migration separately proves real bundled Times and KaiU
+   loading, exact PDF font identities, and English/CJK public routes; it does not
+   add unbundled Noto files as test dependencies.
+5. Keep the top-level/nested multi-figure parser deferred until both shared
    scratch state and all row-dispatch routes are covered.
-5. Keep dynamic theorem-format/counter families deferred; they are not the same
+6. Keep dynamic theorem-format/counter families deferred; they are not the same
    state machine as theorem-content `title`/`label` parsing.
-6. Do not claim package removal while 42 direct `pgfkeys`/`pgfkeysvalueof`
-   references remain across four files or while PGF/TikZ keeps `pgfkeys` active
+7. Do not claim package removal while 38 direct `pgfkeys`/`pgfkeysvalueof`
+   references remain across three files or while PGF/TikZ keeps `pgfkeys` active
    transitively.
-7. Continue requiring focused semantic checks, full text/normalized bbox/fonts,
+8. Continue requiring focused semantic checks, full text/normalized bbox/fonts,
    all-page fixed-DPI raster identity, exact-HEAD archive verification, extracted
    student ZIP direct build, and exact-SHA hosted checks.
 

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ check: thesis
     ! grep -Eiq 'undefined references|undefined citations|Rerun to get (cross-references|outlines) right' "{{ log }}"
 
 # Run the required build and focused regression test gate.
-test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
+test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
 
 # Internal compatibility gate for every explicitly declared v1 command/environment.
 [private]
@@ -350,6 +350,27 @@ _test-custom-font-files-key-unknown:
     grep -Fq 'unsupported' "{{ build_dir }}/tests/custom-font-files-key-unknown.log"
     ! grep -Fq 'NCKU-TEST-FAIL' "{{ build_dir }}/tests/custom-font-files-key-unknown.log"
     @echo "Custom font filename key unknown-option PASS: deterministic hard error"
+
+# Internal contract for font-option parser state and English/CJK loading routes.
+[private]
+_test-font-option-contract:
+    mkdir -p "{{ build_dir }}/tests"
+    rm -f "{{ build_dir }}/tests/font-option-contract."*
+    cd "{{ source_dir }}" && xelatex -interaction=nonstopmode -halt-on-error -output-directory=../"{{ build_dir }}/tests" -jobname=font-option-contract ../tests/font-option-contract.tex
+    pdfinfo "{{ build_dir }}/tests/font-option-contract.pdf" > "{{ build_dir }}/tests/font-option-contract.pdfinfo"
+    pdftotext -layout "{{ build_dir }}/tests/font-option-contract.pdf" "{{ build_dir }}/tests/font-option-contract.txt"
+    pdffonts "{{ build_dir }}/tests/font-option-contract.pdf" > "{{ build_dir }}/tests/font-option-contract.fonts"
+    python3 scripts/test/check-font-option-contract.py "{{ build_dir }}/tests"
+
+# Unknown font-option keys remain deterministic hard errors.
+[private]
+_test-font-option-key-unknown:
+    mkdir -p "{{ build_dir }}/tests"
+    rm -f "{{ build_dir }}/tests/font-option-key-unknown."*
+    if (cd "{{ source_dir }}" && xelatex -interaction=nonstopmode -halt-on-error -output-directory=../"{{ build_dir }}/tests" -jobname=font-option-key-unknown ../tests/font-option-key-unknown.tex); then echo "unknown font-option key unexpectedly compiled"; exit 1; fi
+    grep -Fq 'unsupported' "{{ build_dir }}/tests/font-option-key-unknown.log"
+    ! grep -Fq 'NCKU-TEST-FAIL' "{{ build_dir }}/tests/font-option-key-unknown.log"
+    @echo "Font option key unknown-option PASS: deterministic hard error"
 
 # Internal regression test for bundled Latin/CJK font policy.
 [private]

--- a/scripts/test/check-custom-font-files-contract.py
+++ b/scripts/test/check-custom-font-files-contract.py
@@ -67,8 +67,15 @@ require(
     r"\keys_set:nn { ncku / custom-font-files } {#1}" in source,
     "custom-font private seam does not route through l3keys",
 )
+custom_block_match = re.search(
+    r"\\keys_define:nn \{ ncku / custom-font-files \}(.*?)\\cs_new_protected:Npn \\ncku_custom_font_files_set_keys:n",
+    source,
+    re.DOTALL,
+)
+if custom_block_match is None:
+    raise SystemExit("cannot isolate custom-font filename l3keys block")
 require(
-    source.count(".tl_set_e:N") == 4,
+    custom_block_match.group(1).count(".tl_set_e:N") == 4,
     "custom-font parser must preserve expanded storage for exactly four keys",
 )
 require(
@@ -76,8 +83,8 @@ require(
     "legacy custom-font pgfkeys family remains after migration",
 )
 require(
-    r"/ParseFontOption/.is family" in source,
-    "unrelated font-loading pgfkeys family changed in this slice",
+    r"\keys_define:nn { ncku / font-options }" in source,
+    "adjacent font-option l3keys family is missing",
 )
 require("l3keys2e" not in source, "custom-font source must not use l3keys2e")
 

--- a/scripts/test/check-font-option-contract.py
+++ b/scripts/test/check-font-option-contract.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Verify font-option parser state, rendered fonts, and source boundary."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("build_dir", type=Path)
+args = parser.parse_args()
+
+build = args.build_dir
+log = (build / "font-option-contract.log").read_text(errors="replace")
+text = (build / "font-option-contract.txt").read_text(errors="replace")
+pdfinfo = (build / "font-option-contract.pdfinfo").read_text(errors="replace")
+fonts = (build / "font-option-contract.fonts").read_text(errors="replace")
+source = Path("thesis/template/command/cmd-font.tex").read_text()
+normalized_log = re.sub(r"\s+", " ", log)
+
+markers = [
+    "NCKU-FONT-OPTION-FULL: times.ttf|timesi.ttf|timesbd.ttf|timesbi.ttf",
+    "NCKU-FONT-OPTION-PARTIAL: ||timesbd.ttf|",
+    "NCKU-FONT-OPTION-OMITTED: |||",
+    "NCKU-TEST-PASS: font option parser and English/CJK loading routes",
+]
+for marker in markers:
+    require(marker in normalized_log, f"missing font-option marker: {marker}")
+require("NCKU-TEST-FAIL:" not in log, "font-option fixture emitted failure marker")
+
+for phrase in [
+    "Normal English and 中文普通字型。",
+    "Italic English and 中文斜體字型。",
+    "Bold English and 中文粗體字型。",
+    "Bold italic English and 中文粗斜體字型。",
+]:
+    require(phrase in text, f"missing rendered font-option text: {phrase}")
+
+require(re.search(r"^Pages:\s+1$", pdfinfo, re.MULTILINE) is not None, "focused PDF is not one page")
+require(re.search(r"^Page size:.*A4", pdfinfo, re.MULTILINE) is not None, "focused PDF is not A4")
+for font_name in [
+    "TimesNewRomanPSMT",
+    "TimesNewRomanPS-ItalicMT",
+    "TimesNewRomanPS-BoldMT",
+    "TimesNewRomanPS-BoldItalicMT",
+]:
+    require(font_name in fonts, f"focused PDF missing expected font: {font_name}")
+require(
+    fonts.count("DFKaiShu-SB-Estd-BF") == 4,
+    "focused PDF must contain KaiU normal/fake-bold/fake-slant/fake-bold-slant subsets",
+)
+
+require(
+    r"\newcommand{\NCKUPrivateSetFontOptionKeys}[1]" in source,
+    "font-option private parser seam is missing",
+)
+require(
+    source.count(r"\NCKUPrivateSetFontOptionKeys{#1}") == 2,
+    "English and CJK setters do not both route through the private seam",
+)
+require(
+    r"/ParseFontOption/.is family" in source,
+    "legacy font-option pgfkeys family is missing before migration",
+)
+require(
+    r"\keys_define:nn { ncku / custom-font-files }" in source,
+    "completed custom-font filename l3keys family changed unexpectedly",
+)
+require("l3keys2e" not in source, "font source must not use l3keys2e")
+
+print("Font option contract PASS: expanded state, reset, English/CJK rendering, fonts, and source boundary")

--- a/scripts/test/check-font-option-contract.py
+++ b/scripts/test/check-font-option-contract.py
@@ -58,7 +58,7 @@ require(
 )
 
 require(
-    r"\newcommand{\NCKUPrivateSetFontOptionKeys}[1]" in source,
+    r"\cs_new_protected:Npn \NCKUPrivateSetFontOptionKeys #1" in source,
     "font-option private parser seam is missing",
 )
 require(
@@ -66,8 +66,27 @@ require(
     "English and CJK setters do not both route through the private seam",
 )
 require(
-    r"/ParseFontOption/.is family" in source,
-    "legacy font-option pgfkeys family is missing before migration",
+    r"\keys_define:nn { ncku / font-options }" in source,
+    "font-option l3keys family is missing",
+)
+require(
+    r"\keys_set:nn { ncku / font-options } {#1}" in source,
+    "font-option private seam does not route through l3keys",
+)
+font_block_match = re.search(
+    r"\\keys_define:nn \{ ncku / font-options \}(.*?)\\cs_new_protected:Npn \\ncku_font_options_set_keys:n",
+    source,
+    re.DOTALL,
+)
+if font_block_match is None:
+    raise SystemExit("cannot isolate font-option l3keys block")
+require(
+    font_block_match.group(1).count(".tl_set_e:N") == 4,
+    "font-option parser must preserve expanded storage for exactly four keys",
+)
+require(
+    r"/ParseFontOption/.is family" not in source,
+    "legacy font-option pgfkeys family remains after migration",
 )
 require(
     r"\keys_define:nn { ncku / custom-font-files }" in source,
@@ -75,4 +94,4 @@ require(
 )
 require("l3keys2e" not in source, "font source must not use l3keys2e")
 
-print("Font option contract PASS: expanded state, reset, English/CJK rendering, fonts, and source boundary")
+print("Font option contract PASS: l3keys expanded state, reset, English/CJK rendering, fonts, and source boundary")

--- a/tests/font-option-contract.tex
+++ b/tests/font-option-contract.tex
@@ -1,0 +1,45 @@
+% Focused contract for the legacy font-option parser and font-loading routes.
+\input{./template/configure}
+
+% Freeze expanded parser storage independently from fontspec/xeCJK side effects.
+\def\NCKUFontNormalMacro{times.ttf}
+\def\NCKUFontItalicMacro{timesi.ttf}
+\def\NCKUFontBoldMacro{timesbd.ttf}
+\def\NCKUFontBoldItalicMacro{timesbi.ttf}
+\NCKUPrivateSetFontOptionKeys{NormalFont=\NCKUFontNormalMacro,ItalicFont=\NCKUFontItalicMacro,BoldFont=\NCKUFontBoldMacro,BoldItalicFont=\NCKUFontBoldItalicMacro}
+\def\NCKUFontNormalMacro{changed-normal.ttf}
+\def\NCKUFontItalicMacro{changed-italic.ttf}
+\def\NCKUFontBoldMacro{changed-bold.ttf}
+\def\NCKUFontBoldItalicMacro{changed-bold-italic.ttf}
+\typeout{NCKU-FONT-OPTION-FULL: \TmpValueNormalFont|\TmpValueItalicFont|\TmpValueBoldFont|\TmpValueBoldItalicFont}
+
+\NCKUPrivateSetFontOptionKeys{BoldFont=timesbd.ttf}
+\typeout{NCKU-FONT-OPTION-PARTIAL: \TmpValueNormalFont|\TmpValueItalicFont|\TmpValueBoldFont|\TmpValueBoldItalicFont}
+
+\NCKUPrivateSetFontOptionKeys{\empty}
+\typeout{NCKU-FONT-OPTION-OMITTED: \TmpValueNormalFont|\TmpValueItalicFont|\TmpValueBoldFont|\TmpValueBoldItalicFont}
+
+% Exercise both public loading routes with all four keys and bundled files.
+\SetEngMainFont[%
+  NormalFont=times.ttf,
+  ItalicFont=timesi.ttf,
+  BoldFont=timesbd.ttf,
+  BoldItalicFont=timesbi.ttf,
+]{NCKUFontOptionEng}
+\SetChiMainFont[%
+  NormalFont=kaiu.ttf,
+]{NCKUFontOptionChi}
+
+\begin{document}
+\chapter*{Font option contract}
+
+Normal English and 中文普通字型。
+
+\textit{Italic English and 中文斜體字型。}
+
+\textbf{Bold English and 中文粗體字型。}
+
+\textbf{\textit{Bold italic English and 中文粗斜體字型。}}
+
+\typeout{NCKU-TEST-PASS: font option parser and English/CJK loading routes}
+\end{document}

--- a/tests/font-option-key-unknown.tex
+++ b/tests/font-option-key-unknown.tex
@@ -1,0 +1,8 @@
+% Negative contract: unknown font-option keys must fail.
+\input{./template/configure}
+
+\NCKUPrivateSetFontOptionKeys{unsupported=value}
+
+\begin{document}
+\typeout{NCKU-TEST-FAIL: unknown font option key was ignored}
+\end{document}

--- a/thesis/template/command/cmd-font.tex
+++ b/thesis/template/command/cmd-font.tex
@@ -161,10 +161,17 @@
   BoldItalicFont/.estore in = \TmpValueBoldItalicFont,
 } % End of \pgfkeys{}
 
+% Keep font-option parsing behind one private seam so parser state and both
+% font-loading routes can be frozen before replacing the implementation.
+\newcommand{\NCKUPrivateSetFontOptionKeys}[1]
+{%
+  \pgfkeys{/ParseFontOption, default, #1}%
+} % End of \newcommand{}
+
 \newcommand{\SetEngMainFont}[2][\empty]
 {%
   % Parse the input
-  \pgfkeys{/ParseFontOption, default, #1}%
+  \NCKUPrivateSetFontOptionKeys{#1}%
   %
   \defaultfontfeatures[#2]{%
     Path = \GetFontDirPath,
@@ -187,7 +194,7 @@
 \newcommand{\SetChiMainFont}[2][\empty]
 {%
   % Parse the input
-  \pgfkeys{/ParseFontOption, default, #1}%
+  \NCKUPrivateSetFontOptionKeys{#1}%
   %
   \setCJKmainfont[%
     Path = \GetFontDirPath,

--- a/thesis/template/command/cmd-font.tex
+++ b/thesis/template/command/cmd-font.tex
@@ -145,28 +145,30 @@
 
 % -------------------------------------------
 
-\pgfkeys
-{
-  /ParseFontOption/.is family, /ParseFontOption,
-  default/.style =
+\ExplSyntaxOn
+\keys_define:nn { ncku / font-options }
   {
-    NormalFont = \empty,
-    ItalicFont = \empty,
-    BoldFont = \empty,
-    BoldItalicFont = \empty,
-  },
-  NormalFont/.estore in = \TmpValueNormalFont,
-  ItalicFont/.estore in = \TmpValueItalicFont,
-  BoldFont/.estore in = \TmpValueBoldFont,
-  BoldItalicFont/.estore in = \TmpValueBoldItalicFont,
-} % End of \pgfkeys{}
+    NormalFont     .tl_set_e:N = \TmpValueNormalFont,
+    ItalicFont     .tl_set_e:N = \TmpValueItalicFont,
+    BoldFont       .tl_set_e:N = \TmpValueBoldFont,
+    BoldItalicFont .tl_set_e:N = \TmpValueBoldItalicFont,
+  }
 
-% Keep font-option parsing behind one private seam so parser state and both
-% font-loading routes can be frozen before replacing the implementation.
-\newcommand{\NCKUPrivateSetFontOptionKeys}[1]
-{%
-  \pgfkeys{/ParseFontOption, default, #1}%
-} % End of \newcommand{}
+\cs_new_protected:Npn \ncku_font_options_set_keys:n #1
+  {
+    \tl_clear:N \TmpValueNormalFont
+    \tl_clear:N \TmpValueItalicFont
+    \tl_clear:N \TmpValueBoldFont
+    \tl_clear:N \TmpValueBoldItalicFont
+    \tl_if_eq:nnF {#1} { \empty }
+      { \keys_set:nn { ncku / font-options } {#1} }
+  }
+
+% Keep font-option parsing behind one private seam. Fontspec and xeCJK loading
+% remain in the unchanged public English and CJK setters below.
+\cs_new_protected:Npn \NCKUPrivateSetFontOptionKeys #1
+  { \ncku_font_options_set_keys:n {#1} }
+\ExplSyntaxOff
 
 \newcommand{\SetEngMainFont}[2][\empty]
 {%


### PR DESCRIPTION
## Summary

- freeze the legacy `/ParseFontOption` contract behind one private seam
- migrate only that four-key parser from `pgfkeys` to `l3keys`
- preserve expanded storage, per-call reset, unknown-key hard errors, and both public English/CJK loading routes
- exercise real bundled Times and KaiU files and assert the resulting embedded PDF fonts
- keep every downstream `fontspec` and `xeCJK` call and public command signature unchanged
- scope the adjacent custom-font source checker to its own key block
- update the modernization inventory from 42 references across four files to 38 across three files

## Boundary

This PR does **not**:

- change font assets, font policy, fake-bold/fake-slant policy, or rendering engine
- add unbundled Noto files as fixture dependencies
- change custom-font filename alias behavior
- change multi-figure, theorem registry, or numbering key families
- use `l3keys2e`
- tag, release, or modify Overleaf

## Validation

- focused legacy and `l3keys` parser/loading contracts: PASS
- unknown font-option key hard-error contract: PASS
- adjacent custom-font filename positive/negative contracts: PASS
- focused text/bbox/font-table/200-DPI raster identity: identical
- exact-head `just ci`: PASS
- canonical 271-page A4 text: identical
- normalized bbox words: 40,823 identical
- canonical font table: identical
- canonical 120-DPI raster: 271/271 identical
- `just release review`: PASS
- extracted student ZIP direct XeLaTeX/latexmk build: 271 A4 pages, SyncTeX present, references resolved
- active source/runtime `l3keys2e`: 0/0
- remaining direct `pgfkeys` references: 38 across three files
