### PR TITLE
refactor: migrate chapter title keys to l3keys

### DIFF
--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -25,7 +25,7 @@ student project shape, and complete audited 1.x public API through the 2.x line.
 - [`full-review-repairs.md`](full-review-repairs.md)
 - [`super-optimization.md`](super-optimization.md)
 - [`expl3-internals.md`](expl3-internals.md) — bounded post-release internal
-  modernization with seven output-neutral implementation slices.
+  modernization with eight output-neutral implementation slices.
 - [`pgfkeys-replacement-landscape-2026-07.md`](pgfkeys-replacement-landscape-2026-07.md)
   — dated official-source comparison of `l3keys`, kernel key options,
   `expkv-bundle`, retained PGF/TikZ `pgfkeys`, and deprecated `l3keys2e`.

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,6 +1,6 @@
 # Incremental `expl3` Internal Modernization
 
-Status: first seven bounded slices implemented and validated; pending review
+Status: first eight bounded slices implemented and validated; pending review
 
 ## Intent
 
@@ -148,6 +148,20 @@ Noto font files are not bundled student-archive assets and were not invented as
 fixture dependencies. The public setter signatures and every downstream
 `fontspec`/`xeCJK` call remain unchanged.
 
+### Selected follow-up: Chapter title-format key parsing
+
+The five-key `/CTitleNumberFormat` family is the smallest finite numbering
+family. It moved only after the public Chapter selector was routed through one
+private seam and the existing numbering fixture was extended to freeze expanded
+macro-valued text, partial-call reset, the literal `\empty` omission sentinel,
+unknown-key hard errors, and rendered Chapter title output.
+
+The parser now uses `ncku / chapter-title-format` with five `.tl_set_e:N` keys.
+Its default `BeginText = {Chapter }` retains the trailing space explicitly under
+`expl3` syntax. `\SetNumberingFormat`, the Chapter selector, title-string setup,
+counter rendering, and all other numbering families retain their public APIs and
+behavior. The other nine numbering key families remain on `pgfkeys`.
+
 ### Retained: explicit `xparse`
 
 The LaTeX kernel provides modern document-command interfaces, but it deliberately
@@ -165,11 +179,12 @@ fixture and visible-output proof; a mechanical global rewrite is rejected.
 ### Deferred: remaining `pgfkeys` families
 
 Only the single-figure, single-table, theorem-content, reference-setup,
-custom-font filename, and font-option families moved. The remaining 38 literal
+custom-font filename, font-option, and Chapter title-format families moved. The
+remaining 35 literal
 `\pgfkeys`/`\pgfkeysvalueof` references span three files and expose different
 defaulting, storage, repeated-setup, rendering, and unknown-key behavior. No
-multi-figure, dynamic theorem-format, or numbering key family is approved for
-conversion without its own frozen contract and output proof.
+multi-figure, dynamic theorem-format, or other numbering key family is approved
+for conversion without its own frozen contract and output proof.
 
 ### Retained: `etoolbox`
 
@@ -361,13 +376,40 @@ After the six key-family slices, 38 literal `pgfkeys` references remain across
 three active template files. `cmd-font.tex` now has no direct `pgfkeys`
 references; PGF/TikZ still loads the package transitively.
 
+### Chapter title-format `l3keys` validation result
+
+The Chapter title-format parser replacement passed:
+
+- original-implementation expanded macro-valued text, partial-call reset,
+  literal `\empty` omission, public selector routing, and unknown-key hard-error
+  contracts;
+- default and custom Chapter title/getter rendering inside the existing focused
+  general/appendix numbering matrix;
+- focused one-page text, bounding-box XML, font-table, and 200-DPI raster identity
+  against the same fixture using the original `pgfkeys` parser;
+- fresh exact-HEAD `just ci`, including all adjacent numbering, float, theorem,
+  bibliography, font, archive, diagnostics, and negative-key gates;
+- canonical 271-page A4 text, 40,823 normalized bounding-box words, and
+  font-table identity;
+- identical 120-DPI raster output for all 271 canonical pages;
+- successful `just release review` package generation and verification;
+- a repo-external `latexmk -xelatex -synctex=1` build of the generated student
+  ZIP, producing 271 A4 pages, SyncTeX, and resolved references;
+- zero `l3keys2e` references in active student source.
+
+After the seven key-family slices, 35 literal `pgfkeys` references remain across
+three active template files. `cmd-numbering.tex` retains 27 references for the
+generic formatter, the other general/appendix title levels, and appendix
+numbering; none moved as part of the Chapter-only slice.
+
 ## Next research slice
 
 Do not continue by count alone. Rank candidates by removable dependency cost,
 finite semantics, existing fixture coverage, and output risk. Before another key
 family moves, capture its default, macro-expansion, unknown-key, repeated-setup,
 and rendering contract under the current implementation. The remaining choices
-are coupled multi-figure parsing, dynamic theorem registration, and numbering
-families; none is approved automatically by reference count. Prefer the smallest
+are coupled multi-figure parsing, dynamic theorem registration, and the remaining
+nine numbering families; none is approved automatically by reference count.
+Prefer the smallest
 finite dispatcher or add missing contracts first, and keep every slice
 independently revertible.

--- a/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
+++ b/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
@@ -104,10 +104,10 @@ legacy key package is churn, not modernization.
 
 ## NCKU-specific evidence and judgement
 
-1. Six isolated command families now use `l3keys`: single figure, single table,
+1. Seven isolated command families now use `l3keys`: single figure, single table,
    theorem content, reference setup, custom-font filename parsing, and font-option
-   parsing. Each migration first froze the legacy parser contract and then proved
-   canonical output identity.
+   parsing, plus Chapter title-format parsing. Each migration first froze the
+   legacy parser contract and then proved canonical output identity.
 2. `SetupReference` preserves its default/custom/repeated setup, rendered BibTeX
    output, unknown-key failure, and `apacite[notocbib]` preamble side effect.
 3. Active student source contains zero `l3keys2e` references, and generated
@@ -116,19 +116,23 @@ legacy key package is churn, not modernization.
 4. The font-option migration separately proves real bundled Times and KaiU
    loading, exact PDF font identities, and English/CJK public routes; it does not
    add unbundled Noto files as test dependencies.
-5. Keep the top-level/nested multi-figure parser deferred until both shared
+5. The Chapter title-format migration preserves all five expanded values,
+   per-call defaults including the trailing space in `Chapter `, the public
+   selector route, unknown-key failure, and exact numbering output. The other
+   nine numbering families remain unchanged.
+6. Keep the top-level/nested multi-figure parser deferred until both shared
    scratch state and all row-dispatch routes are covered.
-6. Keep dynamic theorem-format/counter families deferred; they are not the same
+7. Keep dynamic theorem-format/counter families deferred; they are not the same
    state machine as theorem-content `title`/`label` parsing.
-7. Do not claim package removal while 38 direct `pgfkeys`/`pgfkeysvalueof`
+8. Do not claim package removal while 35 direct `pgfkeys`/`pgfkeysvalueof`
    references remain across three files or while PGF/TikZ keeps `pgfkeys` active
    transitively.
-8. Continue requiring focused semantic checks, full text/normalized bbox/fonts,
+9. Continue requiring focused semantic checks, full text/normalized bbox/fonts,
    all-page fixed-DPI raster identity, exact-HEAD archive verification, extracted
    student ZIP direct build, and exact-SHA hosted checks.
 
 For this repository, `l3keys` is the best-fit default because it is official,
-current, already loaded, and has passed five independently reversible,
+current, already loaded, and has passed seven independently reversible,
 output-neutral family migrations. `expkv-bundle` is a credible modern
 alternative, but it solves a more specialized expandability and cross-format
 problem that NCKU has not demonstrated. `pgfkeys` should be reduced where it is

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ check: thesis
     ! grep -Eiq 'undefined references|undefined citations|Rerun to get (cross-references|outlines) right' "{{ log }}"
 
 # Run the required build and focused regression test gate.
-test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
+test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-chapter-title-format-key-unknown _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
 
 # Internal compatibility gate for every explicitly declared v1 command/environment.
 [private]
@@ -133,6 +133,16 @@ _test-numbering-contract:
     pdfinfo "{{ build_dir }}/tests/numbering-contract.pdf" > "{{ build_dir }}/tests/numbering-contract.pdfinfo"
     pdftotext -layout "{{ build_dir }}/tests/numbering-contract.pdf" "{{ build_dir }}/tests/numbering-contract.txt"
     python3 scripts/test/check-numbering-contract.py "{{ build_dir }}/tests"
+
+# Unknown Chapter title-format keys remain deterministic hard errors.
+[private]
+_test-chapter-title-format-key-unknown:
+    mkdir -p "{{ build_dir }}/tests"
+    rm -f "{{ build_dir }}/tests/chapter-title-format-key-unknown."*
+    if (cd "{{ source_dir }}" && xelatex -interaction=nonstopmode -halt-on-error -output-directory=../"{{ build_dir }}/tests" -jobname=chapter-title-format-key-unknown ../tests/chapter-title-format-key-unknown.tex); then echo "unknown Chapter title-format key unexpectedly compiled"; exit 1; fi
+    grep -Fq 'unsupported' "{{ build_dir }}/tests/chapter-title-format-key-unknown.log"
+    ! grep -Fq 'NCKU-TEST-FAIL' "{{ build_dir }}/tests/chapter-title-format-key-unknown.log"
+    @echo "Chapter title-format key unknown-option PASS: deterministic hard error"
 
 # Internal regression test for helper values, state isolation, and equation labels.
 [private]

--- a/scripts/test/check-numbering-contract.py
+++ b/scripts/test/check-numbering-contract.py
@@ -85,7 +85,7 @@ def main() -> None:
 
     source = Path("thesis/template/command/cmd-numbering.tex").read_text()
     require(
-        r"\newcommand\NCKUPrivateSetChapterTitleFormatKeys[1]" in source,
+        r"\cs_new_protected:Npn \NCKUPrivateSetChapterTitleFormatKeys #1" in source,
         "Chapter title-format private seam is missing",
     )
     require(
@@ -93,8 +93,24 @@ def main() -> None:
         "Chapter selector does not route through the private seam exactly once",
     )
     require(
-        r"/CTitleNumberFormat/.is family" in source,
-        "legacy Chapter title-format pgfkeys family is missing before migration",
+        r"\keys_define:nn { ncku / chapter-title-format }" in source,
+        "Chapter title-format l3keys family is missing",
+    )
+    chapter_block_match = re.search(
+        r"\\keys_define:nn \{ ncku / chapter-title-format \}(.*?)\\cs_new_protected:Npn \\ncku_chapter_title_format_set_keys:n",
+        source,
+        re.DOTALL,
+    )
+    require(chapter_block_match is not None, "cannot isolate Chapter title-format l3keys block")
+    if chapter_block_match is None:
+        raise SystemExit("Numbering contract FAIL: cannot isolate Chapter title-format l3keys block")
+    require(
+        chapter_block_match.group(1).count(".tl_set_e:N") == 5,
+        "Chapter parser must preserve expanded storage for exactly five keys",
+    )
+    require(
+        r"/CTitleNumberFormat/.is family" not in source,
+        "legacy Chapter title-format pgfkeys family remains after migration",
     )
     require(
         r"\appto\GetAppendixEquationNumberFormatString{}" not in source,

--- a/scripts/test/check-numbering-contract.py
+++ b/scripts/test/check-numbering-contract.py
@@ -26,6 +26,9 @@ def main() -> None:
     normalized_text = " ".join(text.split())
 
     markers = (
+        "NCKU-CHAPTER-PARSER-EXPANDED:Macro[|]|Center|UpperRoman|:",
+        "NCKU-CHAPTER-PARSER-PARTIAL:Chapter|!|Left|Arabic|.",
+        "NCKU-CHAPTER-PARSER-OMITTED:Chapter||Left|Arabic|.",
         "NCKU-NUMBERING-DEFAULT-GENERAL:Chapter2/2.3/2.3.4//2.3.4.5",
         "NCKU-NUMBERING-DEFAULT-APPENDIX:AppendixB/B.3/B.3.4//B.3.4.5",
         "NCKU-NUMBERING-DEFAULT-GENERAL-GETTERS:2/2.3/2.3.4/",
@@ -40,7 +43,8 @@ def main() -> None:
         "NCKU-NUMBERING-CUSTOM-APPENDIX:AC[B]/AS[B-3]/ASS[B-3-2]/ASSS[B-3-2-1]",
         "NCKU-NUMBERING-NOOP-SELECTOR:GC[",
     )
-    require(log.count("NCKU-NUMBERING-") == len(markers), "unexpected marker count")
+    require(log.count("NCKU-NUMBERING-") == len(markers) - 3, "unexpected numbering marker count")
+    require(log.count("NCKU-CHAPTER-PARSER-") == 3, "unexpected Chapter parser marker count")
     for marker in markers:
         require(marker in compact_log, f"missing or incorrect marker: {marker}")
     require(
@@ -80,6 +84,18 @@ def main() -> None:
         require(fragment in normalized_text, f"missing visible fragment: {fragment}")
 
     source = Path("thesis/template/command/cmd-numbering.tex").read_text()
+    require(
+        r"\newcommand\NCKUPrivateSetChapterTitleFormatKeys[1]" in source,
+        "Chapter title-format private seam is missing",
+    )
+    require(
+        source.count(r"\NCKUPrivateSetChapterTitleFormatKeys{#2}") == 1,
+        "Chapter selector does not route through the private seam exactly once",
+    )
+    require(
+        r"/CTitleNumberFormat/.is family" in source,
+        "legacy Chapter title-format pgfkeys family is missing before migration",
+    )
     require(
         r"\appto\GetAppendixEquationNumberFormatString{}" not in source,
         "appendix equation initializer still appends instead of resetting",

--- a/tests/chapter-title-format-key-unknown.tex
+++ b/tests/chapter-title-format-key-unknown.tex
@@ -1,0 +1,8 @@
+% Negative contract: unknown Chapter title-format keys must fail.
+\input{./template/configure}
+
+\NCKUPrivateSetChapterTitleFormatKeys{unsupported=value}
+
+\begin{document}
+\typeout{NCKU-TEST-FAIL: unknown Chapter title-format key was ignored}
+\end{document}

--- a/tests/numbering-contract.tex
+++ b/tests/numbering-contract.tex
@@ -99,6 +99,18 @@
 \setcounter{appendixsubsection}{2}
 \setcounter{appendixsubsubsection}{1}
 
+% Freeze the Chapter parser independently from the other numbering families.
+\def\NCKUChapterBeginMacro{Macro[}
+\def\NCKUChapterEndMacro{]}
+\NCKUPrivateSetChapterTitleFormatKeys{BeginText=\NCKUChapterBeginMacro,EndText=\NCKUChapterEndMacro,TextAlign=Center,CNumStyle=UpperRoman,SepAtIndex={:}}
+\def\NCKUChapterBeginMacro{Changed[}
+\def\NCKUChapterEndMacro{Changed]}
+\NCKUCapture{NCKUChapterParserExpanded}{\GetCTitleNumberFormatBeginText|\GetCTitleNumberFormatEndText|\GetCTitleNumberFormatTextAlign|\GetCTitleNumberFormatCNumStyle|\GetCTitleNumberFormatSepAtIndex}
+\NCKUPrivateSetChapterTitleFormatKeys{EndText={!}}
+\NCKUCapture{NCKUChapterParserPartial}{\GetCTitleNumberFormatBeginText|\GetCTitleNumberFormatEndText|\GetCTitleNumberFormatTextAlign|\GetCTitleNumberFormatCNumStyle|\GetCTitleNumberFormatSepAtIndex}
+\NCKUPrivateSetChapterTitleFormatKeys{\empty}
+\NCKUCapture{NCKUChapterParserOmitted}{\GetCTitleNumberFormatBeginText|\GetCTitleNumberFormatEndText|\GetCTitleNumberFormatTextAlign|\GetCTitleNumberFormatCNumStyle|\GetCTitleNumberFormatSepAtIndex}
+
 \SetNumberingFormat[Chapter]{%
   BeginText={GC[}, EndText={]}, CNumStyle=Arabic}
 \SetNumberingFormat[Section]{%
@@ -147,6 +159,9 @@
 \SetNumberingFormat[]{BeginText={BROKEN}}
 \NCKUCapture{NCKUNoopSelector}{\GetCTitleNumberFormatBeginText}
 
+\typeout{NCKU-CHAPTER-PARSER-EXPANDED: \NCKUChapterParserExpanded}
+\typeout{NCKU-CHAPTER-PARSER-PARTIAL: \NCKUChapterParserPartial}
+\typeout{NCKU-CHAPTER-PARSER-OMITTED: \NCKUChapterParserOmitted}
 \typeout{NCKU-NUMBERING-DEFAULT-GENERAL: \NCKUDefaultGeneral}
 \typeout{NCKU-NUMBERING-DEFAULT-APPENDIX: \NCKUDefaultAppendix}
 \typeout{NCKU-NUMBERING-DEFAULT-GENERAL-GETTERS: \NCKUDefaultGeneralNumbering}

--- a/thesis/template/command/cmd-numbering.tex
+++ b/thesis/template/command/cmd-numbering.tex
@@ -198,30 +198,32 @@
 
 % ---------------------------
 
-\pgfkeys
-{
-  /CTitleNumberFormat/.is family, /CTitleNumberFormat,
-  default/.style =
+\ExplSyntaxOn
+\keys_define:nn { ncku / chapter-title-format }
   {
-    BeginText = {Chapter },
-    EndText = \empty,
-    TextAlign = {Left}, % Useless for Chapter
-    CNumStyle = Arabic,
-    SepAtIndex = {.},
-  },
-  BeginText/.estore in = \GetCTitleNumberFormatBeginText,
-  EndText/.estore in = \GetCTitleNumberFormatEndText,
-  TextAlign/.estore in = \GetCTitleNumberFormatTextAlign,
-  CNumStyle/.estore in = \GetCTitleNumberFormatCNumStyle,
-  SepAtIndex/.estore in = \GetCTitleNumberFormatSepAtIndex,
-} % End of \pgfkeys{}
+    BeginText  .tl_set_e:N = \GetCTitleNumberFormatBeginText,
+    EndText    .tl_set_e:N = \GetCTitleNumberFormatEndText,
+    TextAlign  .tl_set_e:N = \GetCTitleNumberFormatTextAlign,
+    CNumStyle  .tl_set_e:N = \GetCTitleNumberFormatCNumStyle,
+    SepAtIndex .tl_set_e:N = \GetCTitleNumberFormatSepAtIndex,
+  }
 
-% Keep Chapter title-format parsing behind one private seam so this family can
-% be migrated independently from the other numbering families.
-\newcommand\NCKUPrivateSetChapterTitleFormatKeys[1]
-{%
-  \pgfkeys{/CTitleNumberFormat, default, #1}%
-} % End of \newcommand{}
+\cs_new_protected:Npn \ncku_chapter_title_format_set_keys:n #1
+  {
+    \tl_set:Nn \GetCTitleNumberFormatBeginText { Chapter~ }
+    \tl_clear:N \GetCTitleNumberFormatEndText
+    \tl_set:Nn \GetCTitleNumberFormatTextAlign { Left }
+    \tl_set:Nn \GetCTitleNumberFormatCNumStyle { Arabic }
+    \tl_set:Nn \GetCTitleNumberFormatSepAtIndex { . }
+    \tl_if_eq:nnF {#1} { \empty }
+      { \keys_set:nn { ncku / chapter-title-format } {#1} }
+  }
+
+% Keep Chapter title-format parsing behind one private seam; all other
+% numbering key families remain on their existing implementation.
+\cs_new_protected:Npn \NCKUPrivateSetChapterTitleFormatKeys #1
+  { \ncku_chapter_title_format_set_keys:n {#1} }
+\ExplSyntaxOff
 
 \newcommand\GetChapterTitleNumberFormatString{}
 \newcommand\SetupChapterTitleNumberFormatString

--- a/thesis/template/command/cmd-numbering.tex
+++ b/thesis/template/command/cmd-numbering.tex
@@ -216,6 +216,13 @@
   SepAtIndex/.estore in = \GetCTitleNumberFormatSepAtIndex,
 } % End of \pgfkeys{}
 
+% Keep Chapter title-format parsing behind one private seam so this family can
+% be migrated independently from the other numbering families.
+\newcommand\NCKUPrivateSetChapterTitleFormatKeys[1]
+{%
+  \pgfkeys{/CTitleNumberFormat, default, #1}%
+} % End of \newcommand{}
+
 \newcommand\GetChapterTitleNumberFormatString{}
 \newcommand\SetupChapterTitleNumberFormatString
 {%
@@ -931,7 +938,7 @@
 {%
   \ifthenelse{\equal{#1}{Chapter}}
   {%
-    \pgfkeys{/CTitleNumberFormat, default, #2}%
+    \NCKUPrivateSetChapterTitleFormatKeys{#2}%
   }{}%
   %
   \ifthenelse{\equal{#1}{Section}}


### PR DESCRIPTION
## Summary

- freeze the legacy five-key `/CTitleNumberFormat` contract behind one private seam
- migrate only the Chapter title-format parser from `pgfkeys` to `l3keys`
- preserve expanded values, per-call defaults, the literal `\empty` omission sentinel, public selector routing, and unknown-key hard errors
- retain the explicit trailing space in the default `BeginText = {Chapter }`
- leave the generic formatter and the other nine numbering key families unchanged
- update the `expl3`/`pgfkeys` inventory and validation notes

## Scope

This is one independently reversible parser-only slice. It does not change public signatures, counter rendering, selector behavior, the other numbering families, theorem registration, multi-figure parsing, package loading, Overleaf, tags, or releases.

Current student-source inventory after the slice:

- 35 direct `pgfkeys`/`pgfkeysvalueof` references across three files
- 27 references remain in `cmd-numbering.tex`
- seven `l3keys` families across six files
- zero `l3keys2e` source references

## Validation

- focused legacy and migrated numbering contracts: PASS
- macro-valued expansion, partial reset, omission sentinel, and unknown-key hard error: PASS
- focused one-page text/bbox XML/font table/200-DPI raster: identical
- exact-HEAD `just ci`: PASS
- canonical PDF: 271 A4 pages
- canonical text and font table: identical
- normalized bbox words: 40,823 identical
- canonical 120-DPI raster: 271/271 identical
- `just release review`: PASS
- extracted student ZIP direct `latexmk -xelatex -synctex=1` build: 271 A4 pages, SyncTeX present, references resolved

## Commits

- `016bc7f` test: freeze chapter title format keys
- `4c44173` refactor: use l3keys for chapter title format
- `2218ec2` docs: record chapter title key migration
