### PR TITLE
refactor: migrate multi-figure keys to l3keys

### DIFF
--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -25,7 +25,7 @@ student project shape, and complete audited 1.x public API through the 2.x line.
 - [`full-review-repairs.md`](full-review-repairs.md)
 - [`super-optimization.md`](super-optimization.md)
 - [`expl3-internals.md`](expl3-internals.md) — bounded post-release internal
-  modernization with nine output-neutral implementation slices.
+  modernization with ten output-neutral implementation slices.
 - [`pgfkeys-replacement-landscape-2026-07.md`](pgfkeys-replacement-landscape-2026-07.md)
   — dated official-source comparison of `l3keys`, kernel key options,
   `expkv-bundle`, retained PGF/TikZ `pgfkeys`, and deprecated `l3keys2e`.

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,6 +1,6 @@
 # Incremental `expl3` Internal Modernization
 
-Status: first nine bounded slices implemented and validated; pending review
+Status: first ten bounded slices implemented and validated; pending review
 
 ## Intent
 
@@ -173,6 +173,14 @@ separate negative matrix proves 9/9 unknown-key hard errors.
 No direct `pgfkeys` references remain in `cmd-numbering.tex`. Existing default,
 custom, repeated, dynamic-counter, title, reference, figure/table/equation, and
 unknown-selector rendering contracts remain unchanged.
+
+### Selected follow-up: multi-figure key parsing
+
+The top-level five-key `InsertFigures` parser and nested five-key subfigure parser
+now use independent `l3keys` families behind their existing public commands. The
+focused contract freezes expanded, partial-reset, and literal-`\empty` behavior,
+2/2 unknown-key hard errors, all one-to-four-per-row helper branches, image assets,
+captions, labels, references, opacity, and the existing no-op alignment keys.
 
 ### Retained: explicit `xparse`
 
@@ -419,9 +427,9 @@ numbering; none moved as part of the Chapter-only slice.
 Do not continue by count alone. Rank candidates by removable dependency cost,
 finite semantics, existing fixture coverage, and output risk. Before another key
 family moves, capture its default, macro-expansion, unknown-key, repeated-setup,
-and rendering contract under the current implementation. The remaining choices
-are coupled multi-figure parsing and dynamic theorem registration; neither is
-approved automatically by reference count.
+and rendering contract under the current implementation. The remaining choice is
+dynamic theorem registration; it is not approved automatically by reference
+count.
 Prefer the smallest
 finite dispatcher or add missing contracts first, and keep every slice
 independently revertible.

--- a/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
+++ b/docs/features/v2/pgfkeys-replacement-landscape-2026-07.md
@@ -104,11 +104,12 @@ legacy key package is churn, not modernization.
 
 ## NCKU-specific evidence and judgement
 
-1. Sixteen independently defined command families now use `l3keys`: single
+1. Eighteen independently defined command families now use `l3keys`: single
    figure, single table, theorem content, reference setup, custom-font filename
    parsing, font-option parsing, Chapter title-format parsing, and all nine
-   remaining numbering families. Each migration first froze the legacy parser
-   contract and then proved canonical output identity.
+   remaining numbering families, and both multi-figure parser levels. Each
+   migration first froze the legacy parser contract and then proved canonical
+   output identity.
 2. `SetupReference` preserves its default/custom/repeated setup, rendered BibTeX
    output, unknown-key failure, and `apacite[notocbib]` preamble side effect.
 3. Active student source contains zero `l3keys2e` references, and generated
@@ -121,13 +122,13 @@ legacy key package is churn, not modernization.
    including significant trailing spaces, public selector routes, 10/10 family
    unknown-key failures, and exact default/custom/dynamic numbering output.
    `cmd-numbering.tex` now contains zero direct `pgfkeys` references.
-6. Keep the top-level/nested multi-figure parser deferred until both shared
-   scratch state and all row-dispatch routes are covered.
+6. The top-level/nested multi-figure parsers preserve shared scratch defaults,
+   2/2 unknown-key failures, and all one-to-four-per-row helper routes.
 7. Keep dynamic theorem-format/counter families deferred; they are not the same
    state machine as theorem-content `title`/`label` parsing.
-8. Do not claim package removal while eight direct `pgfkeys`/`pgfkeysvalueof`
-   references remain across two files or while PGF/TikZ keeps `pgfkeys` active
-   transitively.
+8. Do not claim package removal while two direct `pgfkeys`/`pgfkeysvalueof`
+   references remain in the dynamic theorem registry or while PGF/TikZ keeps
+   `pgfkeys` active transitively.
 9. Continue requiring focused semantic checks, full text/normalized bbox/fonts,
    all-page fixed-DPI raster identity, exact-HEAD archive verification, extracted
    student ZIP direct build, and exact-SHA hosted checks.

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ check: thesis
     ! grep -Eiq 'undefined references|undefined citations|Rerun to get (cross-references|outlines) right' "{{ log }}"
 
 # Run the required build and focused regression test gate.
-test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-numbering-family-contract _test-chapter-title-format-key-unknown _test-numbering-family-key-unknown _test-helper-values _test-deprecated-command-contract _test-float-contract _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
+test: check _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-numbering-family-contract _test-chapter-title-format-key-unknown _test-numbering-family-key-unknown _test-helper-values _test-deprecated-command-contract _test-float-contract _test-multi-figure-key-unknown _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
 
 # Internal compatibility gate for every explicitly declared v1 command/environment.
 [private]
@@ -193,6 +193,11 @@ _test-float-contract:
     pdftotext -layout "{{ build_dir }}/tests/float-contract.pdf" "{{ build_dir }}/tests/float-contract.txt"
     pdfimages -list "{{ build_dir }}/tests/float-contract.pdf" > "{{ build_dir }}/tests/float-contract.images"
     python3 scripts/test/check-float-contract.py "{{ build_dir }}/tests"
+
+# Unknown top-level and nested multi-figure keys remain hard errors.
+[private]
+_test-multi-figure-key-unknown:
+    python3 scripts/test/check-multi-figure-key-unknown.py "{{ build_dir }}/tests"
 
 # Unknown single-figure keys must remain deterministic hard errors.
 [private]

--- a/scripts/test/check-float-contract.py
+++ b/scripts/test/check-float-contract.py
@@ -197,13 +197,17 @@ def main() -> None:
     )
     require(figure_source.count(r"\TmpValuePosition") == 1, "figure pos key became behaviorally active")
     require(figure_source.count(r"\TmpValueAlign") == 1, "figure align key became behaviorally active")
-    require(figures_source.count(r"\TmpMIValueAlign") == 1, "multi-figure align key became behaviorally active")
+    top_runtime = figures_source.split(r"\ExplSyntaxOff", 1)[1]
     require(
-        r"\newcommand\NCKUPrivateSetInsertFiguresKeys[1]" in figures_source,
+        r"\TmpMIValueAlign" not in top_runtime,
+        "multi-figure align key became behaviorally active outside its parser",
+    )
+    require(
+        r"\cs_new_protected:Npn \NCKUPrivateSetInsertFiguresKeys #1" in figures_source,
         "top-level multi-figure private parser seam is missing",
     )
     require(
-        r"\newcommand\NCKUPrivateSetInsertFiguresSubFigureKeys[1]" in figures_source,
+        r"\cs_new_protected:Npn \NCKUPrivateSetInsertFiguresSubFigureKeys #1" in figures_source,
         "nested subfigure private parser seam is missing",
     )
     require(
@@ -215,12 +219,27 @@ def main() -> None:
         "nested subfigure command bypasses its private seam",
     )
     require(
-        r"/InsertFigures/.is family" in figures_source,
-        "legacy top-level multi-figure family is missing before migration",
+        r"\keys_define:nn { ncku / insert-figures }" in figures_source,
+        "top-level multi-figure l3keys family is missing",
     )
     require(
-        r"/InsertFiguresSubFigure/.is family" in figures_source,
-        "legacy nested subfigure family is missing before migration",
+        r"\keys_define:nn { ncku / insert-figures-subfigure }" in figures_source,
+        "nested subfigure l3keys family is missing",
+    )
+    top_block = figures_source.split(
+        r"\keys_define:nn { ncku / insert-figures }", 1
+    )[1].split(r"\cs_new_protected:Npn \ncku_insert_figures_set_keys:n", 1)[0]
+    sub_block = figures_source.split(
+        r"\keys_define:nn { ncku / insert-figures-subfigure }", 1
+    )[1].split(
+        r"\cs_new_protected:Npn \ncku_insert_figures_subfigure_set_keys:n", 1
+    )[0]
+    require(top_block.count(".tl_set_e:N") == 5, "top-level multi-figure key count changed")
+    require(sub_block.count(".tl_set_e:N") == 5, "nested subfigure key count changed")
+    require(r"/InsertFigures/.is family" not in figures_source, "legacy top-level family remains")
+    require(
+        r"/InsertFiguresSubFigure/.is family" not in figures_source,
+        "legacy nested subfigure family remains",
     )
 
     print(

--- a/scripts/test/check-float-contract.py
+++ b/scripts/test/check-float-contract.py
@@ -40,6 +40,22 @@ def main() -> None:
         "NCKU-FIGURE-KEY-DEFAULTS:1.0/0///H//0.4",
         "NCKU-FIGURE-KEY-EXPANDED:1.75/15/ExpandedCaption/ncku:expanded/ignored-pos/ignored-align/0.9",
         "NCKU-FIGURE-KEY-RESET:1.0/0///H//0.4",
+        "NCKU-MULTI-KEY-DEFAULTS:1////0.4",
+        "NCKU-MULTI-KEY-EXPANDED:4/ExpandedMultiCaption/ncku:multi-expanded/ignored-multi-align/0.95",
+        "NCKU-MULTI-KEY-PARTIAL:1/PartialMulti///0.4",
+        "NCKU-MULTI-KEY-OMITTED:1////0.4",
+        "NCKU-SUBFIGURE-KEY-DEFAULTS:1.0/0///",
+        "NCKU-SUBFIGURE-KEY-EXPANDED:1.8/25/ExpandedSubCaption/ncku:sub-expanded/ignored-sub-align",
+        "NCKU-SUBFIGURE-KEY-PARTIAL:1.0/0/PartialSub//",
+        "NCKU-SUBFIGURE-KEY-OMITTED:1.0/0///",
+        "NCKU-MULTI-ROW-ONE:A",
+        "NCKU-MULTI-ROW-ONE:B",
+        "NCKU-MULTI-ROW-TWO:C+D",
+        "NCKU-MULTI-ROW-ONE:E",
+        "NCKU-MULTI-ROW-THREE:F+G+H",
+        "NCKU-MULTI-ROW-TWO:I+J",
+        "NCKU-MULTI-ROW-FOUR:K+L+M+N",
+        "NCKU-MULTI-ROW-TWO:O+P",
     )
     for marker in state_markers:
         require(marker in compact_log, f"missing key-state marker: {marker}")
@@ -182,6 +198,30 @@ def main() -> None:
     require(figure_source.count(r"\TmpValuePosition") == 1, "figure pos key became behaviorally active")
     require(figure_source.count(r"\TmpValueAlign") == 1, "figure align key became behaviorally active")
     require(figures_source.count(r"\TmpMIValueAlign") == 1, "multi-figure align key became behaviorally active")
+    require(
+        r"\newcommand\NCKUPrivateSetInsertFiguresKeys[1]" in figures_source,
+        "top-level multi-figure private parser seam is missing",
+    )
+    require(
+        r"\newcommand\NCKUPrivateSetInsertFiguresSubFigureKeys[1]" in figures_source,
+        "nested subfigure private parser seam is missing",
+    )
+    require(
+        figures_source.count(r"\NCKUPrivateSetInsertFiguresKeys{#1}") == 1,
+        "top-level multi-figure command bypasses its private seam",
+    )
+    require(
+        figures_source.count(r"\NCKUPrivateSetInsertFiguresSubFigureKeys{#1}") == 1,
+        "nested subfigure command bypasses its private seam",
+    )
+    require(
+        r"/InsertFigures/.is family" in figures_source,
+        "legacy top-level multi-figure family is missing before migration",
+    )
+    require(
+        r"/InsertFiguresSubFigure/.is family" in figures_source,
+        "legacy nested subfigure family is missing before migration",
+    )
 
     print(
         "Float contract PASS: single/multi/subfigure/table routes, labels/ref/nameref, "

--- a/scripts/test/check-multi-figure-key-unknown.py
+++ b/scripts/test/check-multi-figure-key-unknown.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Require hard errors for top-level and nested multi-figure unknown keys."""
+from __future__ import annotations
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build_dir", type=Path)
+    args = parser.parse_args()
+    build_dir = args.build_dir.resolve()
+    build_dir.mkdir(parents=True, exist_ok=True)
+    source_dir = Path("thesis").resolve()
+    for level in ("top", "sub"):
+        job = f"multi-figure-key-unknown-{level}"
+        for old in build_dir.glob(f"{job}.*"):
+            old.unlink()
+        tex_input = (
+            rf"\def\NCKUTestMultiParser{{{level}}}"
+            r"\input{../tests/multi-figure-key-unknown.tex}"
+        )
+        result = subprocess.run(
+            ("xelatex", "-interaction=nonstopmode", "-halt-on-error",
+             f"-output-directory={build_dir}", f"-jobname={job}", tex_input),
+            cwd=source_dir, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+            check=False,
+        )
+        if result.returncode == 0:
+            raise SystemExit(f"Multi-figure unknown-key FAIL: {level} compiled")
+        log = (build_dir / f"{job}.log").read_text(errors="replace")
+        if "unsupported" not in log or "NCKU-TEST-FAIL" in log:
+            raise SystemExit(f"Multi-figure unknown-key FAIL: {level} diagnostic")
+    print("Multi-figure unknown-key PASS: 2/2 deterministic hard errors")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/float-contract.tex
+++ b/tests/float-contract.tex
@@ -144,6 +144,49 @@
 \typeout{NCKU-FIGURE-KEY-RESET: \TmpValueScale/\TmpValueAngle/\TmpValueCaption/\TmpValueLabel/\TmpValuePosition/\TmpValueAlign/\TmpValueOpacity}
 \endgroup
 
+% Freeze the top-level and nested multi-figure parsers independently.
+\begingroup
+\NCKUPrivateSetInsertFiguresKeys{\empty}
+\typeout{NCKU-MULTI-KEY-DEFAULTS: \TmpMIValueImagePerRow/\TmpMIValueCaption/\TmpMIValueLabel/\TmpMIValueAlign/\TmpValueOpacity}
+\def\NCKUMultiPerRow{4}
+\def\NCKUMultiCaption{Expanded Multi Caption}
+\def\NCKUMultiLabel{ncku:multi-expanded}
+\def\NCKUMultiAlign{ignored-multi-align}
+\def\NCKUMultiOpacity{0.95}
+\NCKUPrivateSetInsertFiguresKeys{perrow=\NCKUMultiPerRow,caption=\NCKUMultiCaption,label=\NCKUMultiLabel,align=\NCKUMultiAlign,opacity=\NCKUMultiOpacity}
+\typeout{NCKU-MULTI-KEY-EXPANDED: \TmpMIValueImagePerRow/\TmpMIValueCaption/\TmpMIValueLabel/\TmpMIValueAlign/\TmpValueOpacity}
+\NCKUPrivateSetInsertFiguresKeys{caption=Partial Multi}
+\typeout{NCKU-MULTI-KEY-PARTIAL: \TmpMIValueImagePerRow/\TmpMIValueCaption/\TmpMIValueLabel/\TmpMIValueAlign/\TmpValueOpacity}
+\NCKUPrivateSetInsertFiguresKeys{\empty}
+\typeout{NCKU-MULTI-KEY-OMITTED: \TmpMIValueImagePerRow/\TmpMIValueCaption/\TmpMIValueLabel/\TmpMIValueAlign/\TmpValueOpacity}
+
+\NCKUPrivateSetInsertFiguresSubFigureKeys{\empty}
+\typeout{NCKU-SUBFIGURE-KEY-DEFAULTS: \TmpMISubValueScale/\TmpMISubValueAngle/\TmpMISubValueCaption/\TmpMISubValueLabel/\TmpMISubValueAlign}
+\def\NCKUSubScale{1.8}
+\def\NCKUSubAngle{25}
+\def\NCKUSubCaption{Expanded Sub Caption}
+\def\NCKUSubLabel{ncku:sub-expanded}
+\def\NCKUSubAlign{ignored-sub-align}
+\NCKUPrivateSetInsertFiguresSubFigureKeys{scale=\NCKUSubScale,angle=\NCKUSubAngle,caption=\NCKUSubCaption,label=\NCKUSubLabel,align=\NCKUSubAlign}
+\typeout{NCKU-SUBFIGURE-KEY-EXPANDED: \TmpMISubValueScale/\TmpMISubValueAngle/\TmpMISubValueCaption/\TmpMISubValueLabel/\TmpMISubValueAlign}
+\NCKUPrivateSetInsertFiguresSubFigureKeys{caption=Partial Sub}
+\typeout{NCKU-SUBFIGURE-KEY-PARTIAL: \TmpMISubValueScale/\TmpMISubValueAngle/\TmpMISubValueCaption/\TmpMISubValueLabel/\TmpMISubValueAlign}
+\NCKUPrivateSetInsertFiguresSubFigureKeys{\empty}
+\typeout{NCKU-SUBFIGURE-KEY-OMITTED: \TmpMISubValueScale/\TmpMISubValueAngle/\TmpMISubValueCaption/\TmpMISubValueLabel/\TmpMISubValueAlign}
+\endgroup
+
+% Freeze all one-to-four-per-row helper branches without visible output.
+\begingroup
+\renewcommand\InsertSubfigureOneFigure[1]{\typeout{NCKU-MULTI-ROW-ONE: #1}}
+\renewcommand\InsertSubfigureTwoFigure[2]{\typeout{NCKU-MULTI-ROW-TWO: #1+#2}}
+\renewcommand\InsertSubfigureThreeFigure[3]{\typeout{NCKU-MULTI-ROW-THREE: #1+#2+#3}}
+\renewcommand\InsertSubfigureFourFigure[4]{\typeout{NCKU-MULTI-ROW-FOUR: #1+#2+#3+#4}}
+\InsertFiguresOnePerRow{A}{B}
+\InsertFiguresTwoPerRow{C}{D}{E}
+\InsertFiguresThreePerRow{F}{G}{H}{I}{J}
+\InsertFiguresFourPerRow{K}{L}{M}{N}{O}{P}
+\endgroup
+
 References: \ref{ncku:float:single}, \ref{ncku:float:multi},
 \ref{ncku:float:sub-a}, \ref{ncku:float:sub-b}, \ref{ncku:float:sub-c},
 \ref{ncku:float:table-top}, \ref{ncku:float:table-bottom}.

--- a/tests/multi-figure-key-unknown.tex
+++ b/tests/multi-figure-key-unknown.tex
@@ -1,0 +1,11 @@
+% Negative contract: unknown multi-figure keys must fail for both parser levels.
+\input{./template/configure}
+
+\providecommand{\NCKUTestMultiParser}{top}
+\ifthenelse{\equal{\NCKUTestMultiParser}{top}}
+  {\NCKUPrivateSetInsertFiguresKeys{unsupported=value}}
+  {\NCKUPrivateSetInsertFiguresSubFigureKeys{unsupported=value}}
+
+\begin{document}
+\typeout{NCKU-TEST-FAIL: unknown multi-figure key was ignored}
+\end{document}

--- a/thesis/template/command/cmd-figures.tex
+++ b/thesis/template/command/cmd-figures.tex
@@ -46,6 +46,11 @@
   opacity/.estore in = \TmpValueOpacity,
 } % End of \pgfkeys{}
 
+\newcommand\NCKUPrivateSetInsertFiguresKeys[1]
+{%
+  \pgfkeys{/InsertFigures, default, #1}%
+} % End of \newcommand{}
+
 % Insert multi-figure
 % Arg: 1st: Table configure
 %      2~9th: Figure (Max 8 Figures)
@@ -54,7 +59,7 @@
   +G{\empty} +G{\empty} +G{\empty} +G{\empty}}
 {
   % Parse the input
-  \pgfkeys{/InsertFigures, default, #1}%
+  \NCKUPrivateSetInsertFiguresKeys{#1}%
   %
   \begin{figure}[H]%
   \NCKUPrivateDisplayFramedFloatContent{\TmpValueOpacity}{%
@@ -344,11 +349,16 @@
   align/.estore in = \TmpMISubValueAlign,      % Useless, for backporting
 } % End of \pgfkeys{}
 
+\newcommand\NCKUPrivateSetInsertFiguresSubFigureKeys[1]
+{%
+  \pgfkeys{/InsertFiguresSubFigure, default, #1}%
+} % End of \newcommand{}
+
 % Low-level insert image
 \newcommand{\InsertFiguresSubFigure}[2][\empty]
 {
   % Parse the input
-  \pgfkeys{/InsertFiguresSubFigure, default, #1}
+  \NCKUPrivateSetInsertFiguresSubFigureKeys{#1}
   %
   \includegraphics[
     scale=\TmpMISubValueScale,

--- a/thesis/template/command/cmd-figures.tex
+++ b/thesis/template/command/cmd-figures.tex
@@ -28,28 +28,30 @@
 %
 % ----------------------------------------------------------------------------
 
-\pgfkeys
-{
-  /InsertFigures/.is family, /InsertFigures,
-  default/.style =
+\ExplSyntaxOn
+\keys_define:nn { ncku / insert-figures }
   {
-    perrow = 1,
-    caption = \empty,
-    label = \empty,
-    align = \empty,      % Useless, for backporting
-    opacity = 0.4,
-  },
-  perrow/.estore in = \TmpMIValueImagePerRow,
-  caption/.estore in = \TmpMIValueCaption,
-  label/.estore in = \TmpMIValueLabel,
-  align/.estore in = \TmpMIValueAlign,      % Useless, for backporting
-  opacity/.estore in = \TmpValueOpacity,
-} % End of \pgfkeys{}
+    perrow  .tl_set_e:N = \TmpMIValueImagePerRow,
+    caption .tl_set_e:N = \TmpMIValueCaption,
+    label   .tl_set_e:N = \TmpMIValueLabel,
+    align   .tl_set_e:N = \TmpMIValueAlign,
+    opacity .tl_set_e:N = \TmpValueOpacity,
+  }
 
-\newcommand\NCKUPrivateSetInsertFiguresKeys[1]
-{%
-  \pgfkeys{/InsertFigures, default, #1}%
-} % End of \newcommand{}
+\cs_new_protected:Npn \ncku_insert_figures_set_keys:n #1
+  {
+    \tl_set:Nn \TmpMIValueImagePerRow { 1 }
+    \tl_clear:N \TmpMIValueCaption
+    \tl_clear:N \TmpMIValueLabel
+    \tl_clear:N \TmpMIValueAlign
+    \tl_set:Nn \TmpValueOpacity { 0.4 }
+    \tl_if_eq:nnF {#1} { \empty }
+      { \keys_set:nn { ncku / insert-figures } {#1} }
+  }
+
+\cs_new_protected:Npn \NCKUPrivateSetInsertFiguresKeys #1
+  { \ncku_insert_figures_set_keys:n {#1} }
+\ExplSyntaxOff
 
 % Insert multi-figure
 % Arg: 1st: Table configure
@@ -331,28 +333,30 @@
 
 % ----------------------------------------------------------------------------
 
-\pgfkeys
-{
-  /InsertFiguresSubFigure/.is family, /InsertFiguresSubFigure,
-  default/.style =
+\ExplSyntaxOn
+\keys_define:nn { ncku / insert-figures-subfigure }
   {
-    scale = 1.0,
-    angle = 0,
-    caption = \empty,
-    label = \empty,
-    align = \empty,      % Useless, for backporting
-  },
-  scale/.estore in = \TmpMISubValueScale,
-  angle/.estore in = \TmpMISubValueAngle,
-  caption/.estore in = \TmpMISubValueCaption,
-  label/.estore in = \TmpMISubValueLabel,
-  align/.estore in = \TmpMISubValueAlign,      % Useless, for backporting
-} % End of \pgfkeys{}
+    scale   .tl_set_e:N = \TmpMISubValueScale,
+    angle   .tl_set_e:N = \TmpMISubValueAngle,
+    caption .tl_set_e:N = \TmpMISubValueCaption,
+    label   .tl_set_e:N = \TmpMISubValueLabel,
+    align   .tl_set_e:N = \TmpMISubValueAlign,
+  }
 
-\newcommand\NCKUPrivateSetInsertFiguresSubFigureKeys[1]
-{%
-  \pgfkeys{/InsertFiguresSubFigure, default, #1}%
-} % End of \newcommand{}
+\cs_new_protected:Npn \ncku_insert_figures_subfigure_set_keys:n #1
+  {
+    \tl_set:Nn \TmpMISubValueScale { 1.0 }
+    \tl_set:Nn \TmpMISubValueAngle { 0 }
+    \tl_clear:N \TmpMISubValueCaption
+    \tl_clear:N \TmpMISubValueLabel
+    \tl_clear:N \TmpMISubValueAlign
+    \tl_if_eq:nnF {#1} { \empty }
+      { \keys_set:nn { ncku / insert-figures-subfigure } {#1} }
+  }
+
+\cs_new_protected:Npn \NCKUPrivateSetInsertFiguresSubFigureKeys #1
+  { \ncku_insert_figures_subfigure_set_keys:n {#1} }
+\ExplSyntaxOff
 
 % Low-level insert image
 \newcommand{\InsertFiguresSubFigure}[2][\empty]

--- a/todos/complete-pgfkeys-modernization.md
+++ b/todos/complete-pgfkeys-modernization.md
@@ -63,19 +63,19 @@ Complete the compatibility-preserving migration of repository-owned command pars
 ### Current evidence
 
 Baseline merged-main: `650a6d9c89a56250e57d6ff652b83a1324d5c541`.
-After the numbering subsystem migration:
+After the numbering and multi-figure subsystem migrations:
 
-- Eight direct `pgfkeys`/`pgfkeysvalueof` references remain across two files.
+- Two direct `pgfkeys`/`pgfkeysvalueof` references remain in one file.
 - `cmd-numbering.tex` has zero direct references after migrating nine families.
-- `cmd-figures.tex` owns six references across top-level and nested multi-figure families.
+- `cmd-figures.tex` has zero direct references after migrating both parser levels.
 - `cmd-theorem.tex` owns two dynamic-registry references.
-- Sixteen command key families use `l3keys`; active student source has zero `l3keys2e` references.
+- Eighteen command key families use `l3keys`; active student source has zero `l3keys2e` references.
 - Exact merged-main `just ci` and hosted push run 29664936529 pass.
 
 ## Progress
 
 - [x] Merge validated Chapter title-format PR #87.
 - [x] Migrate the remaining nine numbering families.
-- [ ] Migrate top-level and nested multi-figure families.
+- [x] Migrate top-level and nested multi-figure families.
 - [ ] Migrate or explicitly retain dynamic theorem parsing from evidence.
 - [ ] Run final zero-reference/retention audit and graduate this brief into `docs/features/v2/`.


### PR DESCRIPTION
## Summary

- freeze top-level and nested multi-figure parser semantics and all one-to-four-per-row helper routes
- migrate both five-key families to independent l3keys parsers
- preserve public commands, captions, labels, references, images, opacity, and no-op alignment keys

## Validation

- focused parser/rendering and 2/2 unknown-key contracts: PASS
- focused text/bbox/fonts/images/200-DPI raster: identical
- exact-head just ci: PASS
- canonical 271 A4 pages, 40,823 normalized bbox words, text/fonts, 271/271 120-DPI raster: identical
- just release review and extracted student ZIP direct build: PASS
- remaining direct pgfkeys references: 2, both in cmd-theorem.tex
