### PR TITLE
docs: prepare v2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Current university and department requirements always override template guidance
 
 ## 2.x
 
+### [v2.0.1.260719010734](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.1.260719010734) — 2026-07-19
+
+- Replaces all repository-owned generic `pgfkeys` command parsers with 19 native
+  `l3keys` families while preserving the complete audited 1.x public API.
+- Preserves parser defaults, macro expansion, repeated-call resets, omission
+  behavior, unknown-key failures, theorem registries, numbering, and float routes.
+- Keeps the canonical NCKU teaching document at 271 A4 pages with identical text,
+  normalized word geometry, font table, and 271/271 fixed-DPI page rasters.
+- Removes the redundant explicit `pgfkeys` load; PGF/TikZ remains available
+  transitively for existing visual framing rather than command parsing.
+
 ### [v2.0.0.260717130231](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.0.260717130231) — 2026-07-17
 
 V2 modernizes the template architecture while preserving XeLaTeX, the established

--- a/docs/features/v2/README.md
+++ b/docs/features/v2/README.md
@@ -1,6 +1,10 @@
 # V2 Template Modernization
 
-Status: shipped as [`v2.0.0.260717130231`](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.0.260717130231) on 2026-07-17
+Status: base shipped as
+[`v2.0.0.260717130231`](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.0.260717130231)
+on 2026-07-17; output-neutral parser modernization shipped as
+[`v2.0.1.260719010734`](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.1.260719010734)
+on 2026-07-19
 
 V2 modernizes the XeLaTeX template while preserving the established NCKU output,
 student project shape, and complete audited 1.x public API through the 2.x line.

--- a/docs/features/v2/expl3-internals.md
+++ b/docs/features/v2/expl3-internals.md
@@ -1,7 +1,8 @@
 # Incremental `expl3` Internal Modernization
 
-Status: eleven bounded slices implemented and validated; command-parser
-migration complete
+Status: command-parser migration complete; eleven bounded slices implemented,
+validated, and released as
+[`v2.0.1.260719010734`](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.1.260719010734)
 
 ## Intent
 


### PR DESCRIPTION
## Summary
- record the completed output-neutral parser modernization in the changelog
- bind the completed v2 feature records to the immutable v2.0.1 release identity

## Validation
- `just clean && just ci`
- clean worktree
- exact local/remote head parity
