### PR TITLE
docs: use short-lived feature branches

### DIFF
--- a/.agents/skills/repo-maintenance/SKILL.md
+++ b/.agents/skills/repo-maintenance/SKILL.md
@@ -208,10 +208,14 @@ a local or workflow artifact alone is insufficient.
 
 ## Development Branch and Hosted Test Gate
 
-The Test workflow push filter covers `main` and `feat/**`. Use the `feat/**`
-namespace for development branches (for example, `feat/v2.x`) so every pushed
-update automatically enters the required hosted test gate. A bare
-version-shaped branch such as `v2.x` does not match that filter.
+The Test workflow push filter covers `main` and `feat/**`. Create short-lived
+development branches as `feat/<short-name>` from current `main` so every pushed
+update automatically enters the required hosted test gate. Merge through a pull
+request, then delete local and remote feature refs after proving that the branch
+has no commits unique to `main`. Keep `main` as the only persistent development
+branch. A bare version-shaped branch such as `v2.x` does not match the workflow
+filter and a long-lived version integration branch is not part of the current
+post-release policy.
 
 After every feature-branch push:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,7 @@ Repository maintenance skill: `.agents/skills/repo-maintenance/SKILL.md`
 
 ## V2 modernization outcome
 
-The `feat/v2.x` branch is the only planned development branch after v1.8. It
-skips a separate v1.9 release and delivers a compatibility-preserving v2
+V2 skipped a separate v1.9 release and delivered a compatibility-preserving
 architecture that:
 
 1. keeps the visible NCKU layout and top-level student project structure;
@@ -31,6 +30,12 @@ architecture that:
 
 Implement this outcome as small validated commits. A v2 version line does not
 authorize a one-shot rewrite or an unverified visual redesign.
+
+Post-release maintenance uses short-lived `feat/<short-name>` branches created
+from current `main`. Merge each validated branch through a pull request, then
+delete its local and remote refs after proving it has no commits unique to
+`main`. `main` is the only persistent development branch; do not retain a
+long-lived version integration branch.
 
 ## Canonical commands
 


### PR DESCRIPTION
## Summary
- make `main` the only persistent development branch
- use short-lived `feat/<short-name>` branches and delete them after merge
- retire the stale long-lived `feat/v2.x` policy without rewriting historical feature records

## Validation
- `just test`
- `git diff --check`
