### PR TITLE
docs: restore bilingual template identity

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-<!-- doc-pair: root-readme; lang: en; topics: project-overview,release-and-overleaf-status,choose-the-correct-setup,quick-start,downloads-and-examples,migrate-from-1-x,other-institution-profiles,submission-watermark-and-certificate,documentation-and-project-work,other-community-alternatives,licence -->
+<!-- doc-pair: root-readme; lang: en; topics: project-overview,choose-the-correct-setup,quick-start,downloads-and-examples,migrate-from-1-x,other-institution-profiles,submission-watermark-and-certificate,documentation-and-project-work,other-community-alternatives,licence -->
 
 [繁體中文](README.md) | [English](README.en.md)
 
@@ -17,14 +17,6 @@ Official guidance last checked on `2026-07-12`:
 - [NCKU thesis system](https://thesis.lib.ncku.edu.tw/)
 - [Submission guidance](https://thesis.lib.ncku.edu.tw/help/aboutedit/)
 - [Curriculum Division thesis-format guidance](https://cid-acad.ncku.edu.tw/p/412-1042-1378.php?Lang=zh-tw)
-
-## Release and Overleaf status
-
-The latest production source and student package are available from [GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest). The current production release is `v2.0.2.260719120024`. V2 preserves the complete machine-audited 1.x public API and direct XeLaTeX student workflow while organizing profiles, compatibility, tests, and downloads.
-
-The existing Overleaf Gallery page remains public. V2 has been uploaded to the original Overleaf project and resubmitted for Gallery update review. Until Overleaf approves it and the public page is independently read back, “submitted” must not be treated as “approved”; GitHub Releases remains canonical for the latest V2 package.
-
-Detailed state: [`docs/features/release-and-distribution.en.md`](docs/features/release-and-distribution.en.md#recorded-gallery-state)
 
 ## Choose the correct setup
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [繁體中文](README.md) | [English](README.en.md)
 
-# 國立成功大學論文範本
+# 國立成功大學碩博士用畢業論文 LaTeX 模版<br>National Cheng Kung University (NCKU)<br>Thesis/Dissertation Template in LaTeX
 
 [在Overleaf開啟範本](https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- doc-pair: root-readme; lang: zh-Hant-TW; topics: project-overview,release-and-overleaf-status,choose-the-correct-setup,quick-start,downloads-and-examples,migrate-from-1-x,other-institution-profiles,submission-watermark-and-certificate,documentation-and-project-work,other-community-alternatives,licence -->
+<!-- doc-pair: root-readme; lang: zh-Hant-TW; topics: project-overview,choose-the-correct-setup,quick-start,downloads-and-examples,migrate-from-1-x,other-institution-profiles,submission-watermark-and-certificate,documentation-and-project-work,other-community-alternatives,licence -->
 
 [繁體中文](README.md) | [English](README.en.md)
 
@@ -15,12 +15,6 @@
 - [成大博碩士論文系統](https://thesis.lib.ncku.edu.tw/)
 - [論文建檔說明](https://thesis.lib.ncku.edu.tw/help/aboutedit/)
 - [教務處課務組論文格式規範](https://cid-acad.ncku.edu.tw/p/412-1042-1378.php?Lang=zh-tw)
-
-## 發行與Overleaf狀態
-
-最新正式原始碼及學生套件由[GitHub Releases](https://github.com/wengan-li/ncku-thesis-template-latex/releases/latest)提供。目前最新production release是`v2.0.2.260719120024`。V2保留完整machine-audited 1.x public API及XeLaTeX學生使用路徑，同時整理profile、相容層、測試及下載套件。
-
-既有Overleaf Gallery頁面仍可公開使用。本模版的V2已上載到原本的Overleaf project並重新提交Gallery update review；在Overleaf批准並完成public read-back前，不能將「已提交」寫成「已批准」，最新V2仍以GitHub Releases為準。
 
 ## 選擇正確設定
 

--- a/scripts/test/check-bilingual-docs.py
+++ b/scripts/test/check-bilingual-docs.py
@@ -268,12 +268,10 @@ def check_public_voice() -> None:
     required_third_person = {
         "README.md": (
             "本模版以XeLaTeX建置",
-            "本模版的V2已上載",
             "本模版將共用renderer",
         ),
         "README.en.md": (
             "This XeLaTeX template supports",
-            "V2 has been uploaded",
             "The template separates shared rendering",
         ),
         "docs/README.md": ("本目錄記錄",),
@@ -288,6 +286,16 @@ def check_public_voice() -> None:
         missing = [marker for marker in markers if marker not in text]
         if missing:
             fail(f"{relative}: missing third-person project voice: {', '.join(missing)}")
+
+    internal_root_status = {
+        "README.md": ("發行與Overleaf狀態", "本模版的V2已上載"),
+        "README.en.md": ("Release and Overleaf status", "V2 has been uploaded"),
+    }
+    for relative, markers in internal_root_status.items():
+        text = read(relative)
+        leaked = [marker for marker in markers if marker in text]
+        if leaked:
+            fail(f"{relative}: internal release status leaked into public README: {', '.join(leaked)}")
 
 
 def check_project_index_scope() -> None:

--- a/thesis/template/style/Customization.en.md
+++ b/thesis/template/style/Customization.en.md
@@ -204,35 +204,21 @@ If Taiwan-year display is required, explicitly override its policy/display gette
 
 `template/compat/v1.tex` loads generic/deprecated adapters throughout 2.x. Only the `ncku` profile loads NCKU college/department presets; an unchanged 1.x NCKU project still selects that default profile and retains its commands. The old `template/command/cmd-college.tex` and `cmd-department.tex` paths remain dormant direct-path compatibility wrappers and do not enter a custom runtime graph automatically. `template/compat/deprecated.tex` preserves 23 commands already unsupported during 1.x with the same names, diagnostics, and `\stop`. The valid one-argument `\RefTo{label}` remains active and is not replaced by a historical comment-only tombstone.
 
-A custom profile loads only the generic institution metadata contract. It does not define or runtime-load NCKU legacy presets, geometry, date policy, or watermark assets. Repository fixtures use an isolated generic configuration and require a real `.fls` recorder file before rejecting NCKU catalogue paths.
+A custom profile loads only the generic institution metadata contract. It does not define or load NCKU presets, geometry, date policy, or watermark assets.
 
 Compatibility preserves correct contracts, not verified defects.
 
 ## Verification
 
-The student package contains no `justfile`, `scripts/`, or `tests`; run direct XeLaTeX/latexmk from the project root containing `thesis.tex`. Full-repository verification uses the focused custom-style, API, V1 migration, and full gates. The custom fixture uses distinct oral/cover dates across Chinese/English Master and Doctoral branches and rejects NCKU visible policy or watermark assets.
-
-Student/package command:
+Run direct XeLaTeX/latexmk from the project root containing `thesis.tex`:
 
 ```bash
 latexmk -xelatex -synctex=1 -interaction=nonstopmode thesis.tex
 pdfinfo thesis.pdf
 ```
 
-Project commands:
-
-```bash
-just _test-custom-style
-python3 scripts/test/check-v1-api.py
-python3 scripts/test/check-v1-project-migration.py
-just test
-just ci
-```
-
-Verify profile registration, A4 pages, names, dates, committee ranges, both degree branches, absence of unintended assets in `.fls`, converged references, and the final rendered cover/certificate pages.
+Confirm that the PDF is A4, then check profile registration, institution and department names, dates, committee ranges, Master/Doctoral branches, and Chinese/English output. A custom profile must not show NCKU wording or watermarks. Finally, confirm converged references and inspect the cover and certificate pages for missing, clipped, or overlapping content.
 
 ## Troubleshooting
 
 For `Template style file ... was not found`, check directory, filename, and `\TemplateStyleName` casing. For `did not register itself`, ensure the profile file calls exactly one matching `\RegisterTemplateStyle`. If custom output shows NCKU wording or assets, check for a direct NCKU-profile input, copied NCKU policy left in the new profile, or institution values hard-coded into a generic renderer.
-
-For any output regression, return to the last buildable commit and reapply one profile change at a time. Do not disable tests, lower expected counts, or edit compatibility manifests.

--- a/thesis/template/style/Customization.md
+++ b/thesis/template/style/Customization.md
@@ -184,27 +184,19 @@ Public commands保持`\SetOralDate{year}{month}{day}`及`\SetCoverDate{year}{mon
 
 `template/compat/v1.tex`在整個2.x line載入generic／deprecated adapters。NCKU college／department presets只由`ncku` profile載入；未修改的1.x NCKU專案仍選擇此預設profile，因此原有commands保持可用。舊`template/command/cmd-college.tex`及`cmd-department.tex` paths只作dormant direct-path compatibility，不會自動進入custom runtime graph。`template/compat/deprecated.tex`保存23個已於1.x停用的public commands，維持原名、diagnostic及`\stop`。有效的一參數`\RefTo{label}`仍在active command file，不會被historical comment-only tombstone取代。
 
-Custom profile只載入generic institution metadata contract，不會define或runtime-load NCKU legacy presets、geometry、date policy或watermark asset。Repository fixtures使用獨立generic config，並以`.fls`正面證明recorder file存在後再拒絕NCKU catalogue paths。
+Custom profile只載入generic institution metadata contract，不會define或載入NCKU presets、geometry、date policy或watermark asset。
 
 ## 驗證
 
-學生套件內沒有`justfile`、`scripts/`或`tests/`；從包含`thesis.tex`的project root使用direct XeLaTeX/latexmk。完整repository則執行focused custom-style、API、V1 migration及full gates。Custom fixture應以不同oral/cover dates同時建置Chinese/English Master及Doctoral branches，確認沒有NCKU visible policy、watermark asset、college catalogue或department catalogue。
+從包含`thesis.tex`的project root使用direct XeLaTeX/latexmk：
 
 ```bash
 latexmk -xelatex -synctex=1 -interaction=nonstopmode thesis.tex
 pdfinfo thesis.pdf
 ```
 
-```bash
-just _test-custom-style
-python3 scripts/test/check-v1-api.py
-python3 scripts/test/check-v1-project-migration.py
-just test
-just ci
-```
+確認PDF為A4，並逐項檢查profile registration、學校及系所名稱、日期、口試委員人數、Master／Doctoral與中英文輸出。Custom profile不應出現NCKU文字或浮水印；最後檢查references已收斂，以及封面與證明書頁面沒有空白、截斷或重疊。
 
 ## 故障處理
 
 如出現`Template style file ... was not found`，檢查directory、filename及`\TemplateStyleName`大小寫。如出現`did not register itself`，確認profile file呼叫一次相同名稱的`\RegisterTemplateStyle`。如custom output出現NCKU文字或asset，檢查是否直接input NCKU profile、從NCKU複製後漏刪policy，或在generic renderer硬編碼institution values。
-
-任何output regression均先回到最後可建置commit，一次重套一個profile change；不要停用tests、降低expected counts或改compatibility manifests。


### PR DESCRIPTION
## Intent

Restore the template's historical bilingual identity at the top of the public README and remove maintainer-only release/test operations from student-facing documentation.

## Historical source

The last commit before `2026-07-19 00:00:00 +0800` was `2218ec237e643b630dc11e6dce51b9c6c185d964`. Its README used the bilingual NCKU thesis/dissertation identity. This PR restores that identity with corrected `LaTeX` product casing as one visual three-line H1:

```text
國立成功大學碩博士用畢業論文 LaTeX 模版
National Cheng Kung University (NCKU)
Thesis/Dissertation Template in LaTeX
```

## Public documentation boundary

- removes the redundant/internal “Release and Overleaf status” section from both root README languages;
- preserves the prominent Overleaf button and GitHub Releases download path;
- keeps detailed release and Gallery state in the project technical records;
- removes repository-only `just`, test-script, `.fls`, expected-count, compatibility-manifest, and commit-rollback guidance from the packaged customization guide;
- keeps direct student-package build instructions, output checks, and actionable profile runtime troubleshooting;
- updates the bilingual checker so internal release status cannot leak back into the public root README.

## Validation

- exact title and three-line rendering source read-back;
- `python3 scripts/test/check-bilingual-docs.py`;
- packaged-document internal-leak scans;
- `just --fmt --check`;
- `git diff --check`;
- full committed `just ci` at `e27a597e4c6adda0428bd1b831a91f407da54eeb`;
- canonical output remains 271 A4 pages.

This PR changes documentation only. It does not create or replace a Release and does not modify/resubmit Overleaf.

## Merge evidence

- merged as `fded5ce30ad166da2b89e7755e2c7484be011b95`;
- exact merged-main Test run: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29689896837;
- remote `main` README was read back through the GitHub API with the restored three-line title and without the internal release-status section;
- local and remote `main` were synchronized and the short-lived branch was deleted after proving it had no commits unique to `main`.
