### PR TITLE
docs: prepare v2.0.3.260719151234 release

### DIFF
--- a/.agents/skills/documentation-management/SKILL.md
+++ b/.agents/skills/documentation-management/SKILL.md
@@ -110,6 +110,11 @@ one is a short link/routing sentence.
 - `CHANGELOG.md` and `CHANGELOG.en.md` both contain the complete release
   history. Traditional Chinese owns the default path; historical mixed-language
   entries are retained rather than rewritten solely for translation.
+- Keep mutable release identity centralized. Public guides and feature summaries
+  link to GitHub Releases and the complete changelog instead of repeating a
+  "current" or "latest" tag that must change after every publication. Exact tags
+  remain appropriate in changelog entries, version-specific migration facts,
+  immutable checksum/read-back evidence, and release artifact names.
 - Apply the same filename rule to every paired documentation surface: Traditional
   Chinese owns `<name>.md`, English owns `<name>.en.md`, and `*.zh-TW.md` paths are
   forbidden. Locale identifiers such as `zh-Hant-TW` remain valid in metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,11 @@ Render and inspect affected pages when cover, margins, pagination, front matter,
 - `CHANGELOG.md` and `CHANGELOG.en.md` both contain the complete release history.
   Traditional Chinese owns the default path; preserve historical mixed-language
   entries rather than rewriting old release evidence solely for translation.
+- Keep mutable release identity centralized. Public guides and feature summaries
+  link to GitHub Releases and the complete changelog instead of repeating a
+  "current" or "latest" tag that must change after every publication. Exact tags
+  remain appropriate in changelog entries, version-specific migration facts,
+  immutable checksum/read-back evidence, and release artifact names.
 - Documentation language, institution profile, cover language, degree, and
   content mode are independent axes. Do not map English readers to `custom` or
   Traditional-Chinese readers to `ncku`.

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -11,6 +11,13 @@ Current university and department requirements always override template guidance
 
 ## 2.x
 
+### [v2.0.3.260719151234](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.3.260719151234) — 2026-07-19
+
+- Restores the project's preserved historical bilingual title and expands thesis-upload, printing, and defense-certificate guidance without presenting historical checks as current university approval.
+- Routes public documentation through stable GitHub Releases and complete changelog links instead of repeating mutable current/latest release identifiers across files.
+- Gives `CHANGELOG.md` a version-neutral title and language switcher while keeping the complete V1 release history in both changelog companions.
+- Does not change XeLaTeX source, public APIs, the student project shape, or PDF layout behavior.
+
 ### [v2.0.2.260719120024](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.2.260719120024) — 2026-07-19
 
 - Organizes student and public documentation into eight complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ## 2.x
 
+### [v2.0.3.260719151234](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.3.260719151234) — 2026-07-19
+
+- 恢復本專案保存的歷史雙語標題，並補回學位論文上傳、列印及學位考試論文證明書指引；歷史查核不再被誤讀為現行學校認可。
+- Public documentation改用穩定的GitHub Releases及完整changelog入口，不再於各文件重複容易過期的「current／latest release」識別。
+- `CHANGELOG.md`改用不綁定版本線的標題及語言switcher，並與英文companion一同保存完整V1 release history。
+- XeLaTeX source、public API、學生project shape及PDF layout behavior沒有變更。
+
 ### [v2.0.2.260719120024](https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.2.260719120024) — 2026-07-19
 
 - 將學生及public documentation整理成8組完整繁中／英文guides與3組繁中摘要／英文technical records；繁中使用default `.md`，英文使用`.en.md`，不再保留`.zh-TW.md` paths。


### PR DESCRIPTION
## Summary
- centralize the durable rule that mutable current/latest release IDs stay out of public guides
- record the complete documentation-only v2.0.3.260719151234 release in both changelogs
- preserve the full V1 history and stable release routing

## Local validation
- `python3 scripts/test/check-bilingual-docs.py`
- `just ci`
- `just release v2.0.3.260719151234`
- exact two-archive allowlist and package verification

## Hosted validation
- branch push Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29692590085
- pull-request Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29692597031
- merged-main Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29692834609
- tag Release workflow: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29693030280

## Published release
- Release: https://github.com/wengan-li/ncku-thesis-template-latex/releases/tag/v2.0.3.260719151234
- source commit: `b3175286ac0f910d22dd6d1e7f1955e843e9de10`
- student ZIP SHA-256: `6e0ad5aadc85e0a70482b0cb6a8a908950d27213d0d1eb705b6a9e2acc5c137b`
- examples ZIP SHA-256: `1f5c9c2c567f87f89e0f94e4be3200090fd1394379ce720e3a6975f05c505717`
- workflow artifacts and public Release assets are byte-identical
- fresh public student ZIP builds directly to a 271-page A4 PDF
- all six public example PDFs passed A4/page-count validation