### PR TITLE
docs: preserve public documentation contract

### DIFF
--- a/.agents/skills/documentation-management/SKILL.md
+++ b/.agents/skills/documentation-management/SKILL.md
@@ -92,6 +92,37 @@ one is a short link/routing sentence.
 - GitHub Release state and Overleaf state are independent. Never turn submitted
   into approved without live public read-back.
 
+### Protected root README contract
+
+The Traditional-Chinese/default root README preserves this historical name as
+one H1 rendered on exactly two visual lines, English first:
+
+```text
+National Cheng Kung University (NCKU) Thesis/Dissertation Template in LaTex
+台灣國立成功大學碩博士用畢業論文 LaTex 模版
+```
+
+The historical `LaTex` spelling is allowed only inside that exact title. Do not
+reorder, translate, split it into three lines, or normalize its spelling without
+explicit owner direction; all current prose still uses `LaTeX`.
+
+Root `README.md` and `README.en.md` must retain equivalent student sections for:
+
+- historical acceptance (`Available to use 已被學校負責單位接受`), clearly
+  distinguished from current approval;
+- current thesis upload and printing guidance, sourced from the live NCKU ETDS
+  page with a checked date;
+- the template-versus-degree-examination-system defense-certificate FAQ, which
+  directs students to the current official system file and keeps generated
+  certificates legacy/example only.
+
+The public root README keeps Overleaf and GitHub Release entry points, but not
+branch/PR workflow, release promotion narration, machine-audit inventories, or
+Overleaf review-state instructions. Packaged customization guidance keeps direct
+`latexmk`, A4/output checks, and actionable profile runtime errors; it excludes
+repository-only `just`/test commands, `.fls` assertions, expected counts,
+compatibility-manifest maintenance, and commit rollback workflow.
+
 ## Bilingual documentation model
 
 - Student/public journeys are complete in formal Taiwan Traditional Chinese
@@ -120,14 +151,19 @@ one is a short link/routing sentence.
   `the project` wording; general workflow remains role-neutral. Refer to Chinese
   cross-institution readers as `其他學校的同學` and English readers as `students
   from other institutions`.
-- Use exact `LaTeX`, `XeLaTeX`, `BibTeX`, `latexmk`, and `SyncTeX` casing. Use
-  `論文範本` in new Chinese prose. Avoid Cantonese-only wording in shipped docs.
+- Use exact `LaTeX`, `XeLaTeX`, `BibTeX`, `latexmk`, and `SyncTeX` casing outside
+  the exact protected historical root title above. Use `論文範本` in new Chinese
+  prose. Avoid Cantonese-only wording in shipped docs.
 - Keep `thesis/conf/conf.tex` byte-identical throughout 2.x. Its bilingual
   companion is `thesis/conf/README.md`; never refresh the V1 migration baseline
   merely to translate comments.
 - Mechanical checks prove structure, links, casing, and selected terminology
   only. Human review must still verify that warnings, actions, defaults, and
   exceptions mean the same thing in both languages.
+- Stable topic/H2 parity is necessary but cannot protect content deleted from
+  both companions. Add positive checker anchors for the protected title, the
+  three student sections, their current official routes, and public/internal
+  audience boundaries.
 
 This model follows authoritative public patterns:
 

--- a/scripts/test/check-bilingual-docs.py
+++ b/scripts/test/check-bilingual-docs.py
@@ -72,6 +72,33 @@ HISTORICAL_BILINGUAL_TITLE = (
     "# National Cheng Kung University (NCKU) Thesis/Dissertation Template in LaTex"
     "<br>台灣國立成功大學碩博士用畢業論文 LaTex 模版"
 )
+REQUIRED_ROOT_README_MARKERS = {
+    "README.md": (
+        "## Available to use 已被學校負責單位接受",
+        "## 學位論文上傳和列印說明",
+        "## 模版和學位考試系統的學位考試論文證明書的FAQ",
+        "https://thesis.lib.ncku.edu.tw/help/aboutedit/",
+        "https://thesis.lib.ncku.edu.tw/",
+        "https://github.com/wengan-li/ncku-thesis-template-latex/issues/30",
+    ),
+    "README.en.md": (
+        "## Available to use / historical acceptance",
+        "## Thesis upload and printing",
+        "## FAQ: template and degree-examination-system defense certificates",
+        "https://thesis.lib.ncku.edu.tw/help/aboutedit/",
+        "https://thesis.lib.ncku.edu.tw/",
+        "https://github.com/wengan-li/ncku-thesis-template-latex/issues/30",
+    ),
+}
+FORBIDDEN_PACKAGED_CUSTOMIZATION_MARKERS = (
+    "just _test-custom-style",
+    "python3 scripts/test/check-v1-api.py",
+    "python3 scripts/test/check-v1-project-migration.py",
+    "Project commands:",
+    "Repository fixtures",
+    "expected counts",
+    "compatibility manifests",
+)
 INLINE_LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 HEADING = re.compile(r"^(#{1,6})\s+(.+?)\s*#*$", re.MULTILINE)
 FENCE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
@@ -259,6 +286,30 @@ def check_language_hygiene() -> None:
         if CJK.search(plain):
             lines = [line for line in plain.splitlines() if CJK.search(line)]
             fail(f"{relative}: CJK prose outside code/switcher: {lines[0]}")
+
+
+def check_protected_public_contract() -> None:
+    for relative, markers in REQUIRED_ROOT_README_MARKERS.items():
+        text = read(relative)
+        missing = [marker for marker in markers if marker not in text]
+        if missing:
+            fail(f"{relative}: missing protected public content: {', '.join(missing)}")
+
+    for relative in (
+        "thesis/template/style/Customization.md",
+        "thesis/template/style/Customization.en.md",
+    ):
+        text = read(relative)
+        leaked = [
+            marker
+            for marker in FORBIDDEN_PACKAGED_CUSTOMIZATION_MARKERS
+            if marker in text
+        ]
+        if leaked:
+            fail(
+                f"{relative}: internal repository guidance leaked into student package: "
+                + ", ".join(leaked)
+            )
 
 
 def check_no_mutable_release_labels() -> None:
@@ -666,6 +717,7 @@ def main() -> int:
         check_no_legacy_locale_suffixes()
         check_no_repeated_language_labels()
         check_language_hygiene()
+        check_protected_public_contract()
         check_no_mutable_release_labels()
         check_public_voice()
         check_project_index_scope()


### PR DESCRIPTION
## Intent

Make the owner-confirmed public documentation lessons durable so future consolidation cannot again remove the template identity or student decision content while still passing only structural pair checks.

## Durable contract

- records the exact historical two-line root README title, including its narrowly scoped legacy `LaTex` spelling;
- records the three protected student sections: historical acceptance, thesis upload/printing, and defense-certificate FAQ;
- records the current-official-versus-historical-evidence boundary;
- records what belongs in public/student docs versus internal release/test/runbook surfaces;
- explains why topic/H2 parity needs positive semantic anchors.

## Mechanical guard

`check-bilingual-docs.py` now requires, in both root README languages:

- all three student section headings;
- current NCKU thesis-system/submission routes;
- the historical certificate discussion route.

It also rejects repository-only custom-style tests, scripts, fixture narration, expected-count policy, and compatibility-manifest guidance from packaged Customization guides.

## Validation

- positive contract path passes;
- negative probe deleting a required section fails;
- negative probe leaking an internal custom-style command fails;
- `python3 scripts/test/check-bilingual-docs.py`;
- `just --fmt --check`;
- `git diff --check`;
- full committed `just ci`;
- canonical output remains 271 A4 pages;
- public prohibited-marker scan passes.

This is a learning/documentation-policy slice only. It does not change student prose, source, release assets, tags, or Overleaf. The owner subsequently authorized merging every remaining branch into `main` and deleting the merged branch refs.

## Hosted validation

- current-head push Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29708201833
- current-head pull-request Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29708202393
- tested head: `01131ea040e4a1429dc3ce170a59cdc15a0011ce`


