### PR TITLE
docs: prioritize student navigation

### DIFF
--- a/.agents/skills/documentation-management/SKILL.md
+++ b/.agents/skills/documentation-management/SKILL.md
@@ -89,6 +89,10 @@ one is a short link/routing sentence.
   stay outside the student ZIP.
 - Root README provides the public overview; `docs/README.md` routes students and
   readers to current guides and shipped project records.
+- Public landing pages and indexes are ordered by reader need: overview, a
+  task-oriented start table, direct student routes, then deeper project records.
+  Keep active-work state, branch mechanics, and implementation chronology out of
+  those public indexes.
 - GitHub Release state and Overleaf state are independent. Never turn submitted
   into approved without live public read-back.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ Render and inspect affected pages when cover, margins, pagination, front matter,
 ## Documentation Standard
 
 - `docs/README.md` is the public project-documentation index and audience router.
+  Public indexes use task-oriented, student-first routes before deeper technical
+  records; active-work state and branch mechanics stay in internal governance.
 - `docs/v1-to-v2-migration.md` is the current 1.x-to-2.x migration guide;
   `thesis/README.md` keeps concise offline steps and `thesis/conf/README.md`
   keeps field-by-field configuration guidance inside the student ZIP.

--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-<!-- doc-pair: root-readme; lang: en; topics: project-overview,historical-acceptance,choose-the-correct-setup,quick-start,downloads-and-examples,migrate-from-1-x,other-institution-profiles,thesis-upload-and-printing,defense-certificate-faq,documentation-and-project-work,other-community-alternatives,licence -->
+<!-- doc-pair: root-readme; lang: en; topics: project-overview,start-by-need,quick-start,choose-the-correct-setup,downloads-and-examples,migrate-from-1-x,other-institution-profiles,historical-acceptance,thesis-upload-and-printing,defense-certificate-faq,documentation-and-project-work,other-community-alternatives,licence -->
 
 [繁體中文](README.md) | [English](README.en.md)
 
@@ -18,24 +18,16 @@ Official guidance last checked on `2026-07-12`:
 - [Submission guidance](https://thesis.lib.ncku.edu.tw/help/aboutedit/)
 - [Curriculum Division thesis-format guidance](https://cid-acad.ncku.edu.tw/p/412-1042-1378.php?Lang=zh-tw)
 
-## Available to use / historical acceptance
+## Start by need
 
-According to records preserved by the project, the template's format/design was checked by the NCKU Library's digital-thesis team in 2015. The Curriculum Division also checked the Chinese and English defense certificates generated at that time. In 2018, the Division separately stated that the template-generated Chinese certificate was unauthorized.
-
-These are historical checks, not evidence that the university, library, degree-examination system, or any department currently accepts every template setting. CSIE is the only department for which the project preserves documented historical use, and that record is not current approval. Verify the rules for the current year and department before use.
-
-## Choose the correct setup
-
-Documentation language, institution profile, cover language, degree, and content mode are separate settings. NCKU students use the `ncku` profile whether they write in Chinese or English; students from other institutions can use `custom` or another institution profile.
-
-| Decision | Choices |
+| What you want to do | Start here |
 | --- | --- |
-| Institution | default `ncku` for NCKU students; custom profile for students from another institution |
-| Cover language | `\DisplayCoverInChi` or `\DisplayCoverInEng` |
-| Degree | `\MasterDegree` or `\PhdDegree` |
-| Content | own `context/context.tex` or `\ExampleMode` teaching example |
-
-Historical checks in 2015 and reports from individual departments are provenance only, not current approval. CSIE is the only department with documented historical use in this repository; every student must still verify current department rules.
+| Start writing a thesis now | [Quick start](#quick-start) and the student-package [`README.en.md`](thesis/README.en.md) |
+| Enter names, titles, degree, and department | [`conf/README.en.md`](thesis/conf/README.en.md) |
+| Upgrade a 1.x project | [1.x-to-2.x migration guide](docs/v1-to-v2-migration.en.md) |
+| Create a style for another institution | [`Customization.en.md`](thesis/template/style/Customization.en.md) |
+| Upload, print, and choose the official certificate | [Thesis upload and printing](#thesis-upload-and-printing) |
+| Review architecture, validation, releases, and Overleaf records | [`docs/README.en.md`](docs/README.en.md) |
 
 ## Quick start
 
@@ -50,6 +42,17 @@ latexmk -xelatex -synctex=1 -interaction=nonstopmode thesis.tex
 ```
 
 Use `thesis.tex` as the root/master document. `latexmk` handles XeLaTeX, BibTeX, and required reruns automatically.
+
+## Choose the correct setup
+
+Documentation language, institution profile, cover language, degree, and content mode are separate settings. NCKU students use the `ncku` profile whether they write in Chinese or English; students from other institutions can use `custom` or another institution profile.
+
+| Decision | Choices |
+| --- | --- |
+| Institution | default `ncku` for NCKU students; custom profile for students from another institution |
+| Cover language | `\DisplayCoverInChi` or `\DisplayCoverInEng` |
+| Degree | `\MasterDegree` or `\PhdDegree` |
+| Content | own `context/context.tex` or `\ExampleMode` teaching example |
 
 ## Downloads and examples
 
@@ -87,6 +90,12 @@ The template separates shared rendering, NCKU policy, and other-institution port
 NCKU students can use the complete [`9-college / 110-department preset catalogue`](thesis/template/style/ncku/README.en.md). Students from other institutions use the generic institution APIs and can follow the explicitly illustrative NTU wiring in [`Customization.en.md`](thesis/template/style/Customization.en.md).
 
 Guide: [`thesis/template/style/Customization.en.md`](thesis/template/style/Customization.en.md)
+
+## Available to use / historical acceptance
+
+According to records preserved by the project, the template's format/design was checked by the NCKU Library's digital-thesis team in 2015. The Curriculum Division also checked the Chinese and English defense certificates generated at that time. In 2018, the Division separately stated that the template-generated Chinese certificate was unauthorized.
+
+These are historical checks, not evidence that the university, library, degree-examination system, or any department currently accepts every template setting. CSIE is the only department for which the project preserves documented historical use, and that record is not current approval. Verify the rules for the current year and department before use.
 
 ## Thesis upload and printing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- doc-pair: root-readme; lang: zh-Hant-TW; topics: project-overview,historical-acceptance,choose-the-correct-setup,quick-start,downloads-and-examples,migrate-from-1-x,other-institution-profiles,thesis-upload-and-printing,defense-certificate-faq,documentation-and-project-work,other-community-alternatives,licence -->
+<!-- doc-pair: root-readme; lang: zh-Hant-TW; topics: project-overview,start-by-need,quick-start,choose-the-correct-setup,downloads-and-examples,migrate-from-1-x,other-institution-profiles,historical-acceptance,thesis-upload-and-printing,defense-certificate-faq,documentation-and-project-work,other-community-alternatives,licence -->
 
 [繁體中文](README.md) | [English](README.en.md)
 
@@ -16,22 +16,16 @@
 - [論文建檔說明](https://thesis.lib.ncku.edu.tw/help/aboutedit/)
 - [教務處課務組論文格式規範](https://cid-acad.ncku.edu.tw/p/412-1042-1378.php?Lang=zh-tw)
 
-## Available to use 已被學校負責單位接受
+## 按需要開始
 
-依本專案保存的歷史紀錄，本模版的格式／設計曾於2015年由成大圖書館系統管理組數位論文小組檢查；本模版當時產生的中英文學位考試論文證明書亦曾由教務處課務組檢查。2018年，課務組另指出本模版產生的中文版證明書未經授權。
-
-以上只屬歷史查核紀錄，不代表目前的學校、圖書館、學位考試系統或任何系所接受本模版的每項設定。資訊工程學系是本專案唯一有保存歷史使用紀錄的系所，但此紀錄亦不等於現行認可。使用前必須核對當年度學校及系所規定。
-
-## 選擇正確設定
-
-文件語言、學校profile、封面語言、學位及內容模式是不同設定。成大同學無論使用中文或英文文件，都使用`ncku` profile；其他學校的同學如要建立自己的範本，可使用`custom`或另一個institution profile。
-
-| 決定 | 選項 |
+| 你想做的事 | 先看這裡 |
 | --- | --- |
-| 學校 | 成大同學使用預設`ncku`；其他學校的同學可使用custom profile |
-| 封面語言 | `\DisplayCoverInChi`或`\DisplayCoverInEng` |
-| 學位 | `\MasterDegree`或`\PhdDegree` |
-| 內容 | 自己的`context/context.tex`或`\ExampleMode`教學範例 |
+| 立即開始撰寫論文 | [快速開始](#快速開始)及學生套件[`README.md`](thesis/README.md) |
+| 填寫姓名、題目、學位及系所 | [`conf/README.md`](thesis/conf/README.md) |
+| 由1.x專案升級 | [`1.x至2.x升級指南`](docs/v1-to-v2-migration.md) |
+| 為其他學校建立樣式 | [`Customization.md`](thesis/template/style/Customization.md) |
+| 上傳論文、列印及選擇正式證明書 | [學位論文上傳和列印說明](#學位論文上傳和列印說明) |
+| 查看架構、驗證、發行及Overleaf記錄 | [`docs/README.md`](docs/README.md) |
 
 ## 快速開始
 
@@ -44,6 +38,17 @@
 ```bash
 latexmk -xelatex -synctex=1 -interaction=nonstopmode thesis.tex
 ```
+
+## 選擇正確設定
+
+文件語言、學校profile、封面語言、學位及內容模式是不同設定。成大同學無論使用中文或英文文件，都使用`ncku` profile；其他學校的同學如要建立自己的範本，可使用`custom`或另一個institution profile。
+
+| 決定 | 選項 |
+| --- | --- |
+| 學校 | 成大同學使用預設`ncku`；其他學校的同學可使用custom profile |
+| 封面語言 | `\DisplayCoverInChi`或`\DisplayCoverInEng` |
+| 學位 | `\MasterDegree`或`\PhdDegree` |
+| 內容 | 自己的`context/context.tex`或`\ExampleMode`教學範例 |
 
 ## 下載內容與範例
 
@@ -73,6 +78,12 @@ defense-certificate-phd.pdf
 本模版將共用renderer、NCKU policy及其他學校port分成`base`、`ncku`及`custom`。學生論文資料仍放在`conf/conf.tex`；學校geometry、名稱、日期政策、文字及assets放在`template/style/<profile>/`。`custom`是neutral skeleton，不是任何學校的ready-to-submit profile；本專案目前亦沒有NTU profile。其他學校的同學可由`template/style/custom/`開始，不要直接修改共用renderer或先載入NCKU再覆寫。
 
 NCKU學生可查看完整[`9個學院／110個系所preset目錄`](thesis/template/style/ncku/README.md)；其他學校的同學則使用generic institution APIs，並參考[`Customization.md`](thesis/template/style/Customization.md)內明確標示為illustrative的NTU wiring例子。
+
+## Available to use 已被學校負責單位接受
+
+依本專案保存的歷史紀錄，本模版的格式／設計曾於2015年由成大圖書館系統管理組數位論文小組檢查；本模版當時產生的中英文學位考試論文證明書亦曾由教務處課務組檢查。2018年，課務組另指出本模版產生的中文版證明書未經授權。
+
+以上只屬歷史查核紀錄，不代表目前的學校、圖書館、學位考試系統或任何系所接受本模版的每項設定。資訊工程學系是本專案唯一有保存歷史使用紀錄的系所，但此紀錄亦不等於現行認可。使用前必須核對當年度學校及系所規定。
 
 ## 學位論文上傳和列印說明
 

--- a/docs/features/README.en.md
+++ b/docs/features/README.en.md
@@ -1,20 +1,27 @@
-<!-- doc-pair: feature-index; lang: en; topics: v2-production-records,record-policy-and-active-work -->
+<!-- doc-pair: feature-index; lang: en; topics: choose-by-need,shipped-records,student-routes -->
 
 [繁體中文](README.md) | [English](README.en.md)
 
 # Shipped feature records
 
-## V2 production records
+## Choose by need
 
-This directory preserves production behavior, durable architecture decisions, and machine-checked evidence. Feature records are not an implementation queue; branch names, temporary boundaries, checkbox progress, and duplicate command transcripts remain in Git history. Each English technical record has a separate Traditional-Chinese executive-summary companion.
+This directory organizes shipped records around the questions that students and project contributors need to answer. Each English technical record has a Traditional-Chinese summary companion available from the page switcher.
+
+| What you need to understand | Start with |
+| --- | --- |
+| What V2 changed, whether 1.x remains compatible, or how other institutions are supported | [`v2-modernization.en.md`](v2-modernization.en.md) |
+| How builds, output, performance, and compatibility are verified | [`validation-and-performance.en.md`](validation-and-performance.en.md) |
+| How downloads, releases, Overleaf, certificates, or watermark policy work | [`release-and-distribution.en.md`](release-and-distribution.en.md) |
+
+## Shipped records
+
+Feature records preserve production behavior, durable architecture decisions, and machine-checked evidence:
 
 - [`v2-modernization.en.md`](v2-modernization.en.md) — product intent, compatibility, architecture, hardened subsystems, and completion boundary.
 - [`validation-and-performance.en.md`](validation-and-performance.en.md) — tests, artifact proof, benchmarks, and accepted/rejected/deferred decisions.
 - [`release-and-distribution.en.md`](release-and-distribution.en.md) — versioning, packages, GitHub Release, Overleaf, retired sample repository, and Draft/watermark policy.
 
-User migration: [`../v1-to-v2-migration.en.md`](../v1-to-v2-migration.en.md)<br>
-Student instructions: [`thesis/README.en.md`](../../thesis/README.en.md)
+## Student routes
 
-## Record policy and active work
-
-Durable compatibility numbers, architecture decisions, measured rejected experiments, and publication boundaries remain because they constrain future maintenance. Bilingual-documentation work is complete: stable language policy remains in current documentation, AGENTS, the repo-local skill, and the deterministic checker, while implementation chronology remains in Git history. No requirement is currently active.
+To write a thesis directly, return to the need-based entry points in the [root `README.en.md`](../../README.en.md) or read the student-package [`thesis/README.en.md`](../../thesis/README.en.md). Existing 1.x projects should use the [1.x-to-2.x migration guide](../v1-to-v2-migration.en.md).

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,17 +1,27 @@
-<!-- doc-pair: feature-index; lang: zh-Hant-TW; topics: v2-production-records,record-policy-and-active-work -->
+<!-- doc-pair: feature-index; lang: zh-Hant-TW; topics: choose-by-need,shipped-records,student-routes -->
 
 [繁體中文](README.md) | [English](README.en.md)
 
 # 已發行功能記錄
 
-## V2正式記錄
+## 按需要選擇記錄
 
-本目錄保存production behavior、durable architecture decisions及machine-checked evidence。Feature records不是implementation queue；branch names、temporary boundaries、checkbox progress及重複command transcripts留在Git history。繁中頁面提供executive summary，並由頁首switcher連到canonical英文technical record。
+本目錄按同學或專案參與者想解答的問題整理已發行記錄。繁中頁面提供摘要，頁首可切換至較完整的英文technical record。
+
+| 想了解的內容 | 先看這份記錄 |
+| --- | --- |
+| V2改變了甚麼、1.x是否相容、如何支援其他學校 | [`v2-modernization.md`](v2-modernization.md) |
+| 如何驗證建置、輸出、效能及相容性 | [`validation-and-performance.md`](validation-and-performance.md) |
+| 如何下載、發行、使用Overleaf或理解證明書／浮水印政策 | [`release-and-distribution.md`](release-and-distribution.md) |
+
+## 已發行記錄
+
+Feature records保存production behavior、durable architecture decisions及machine-checked evidence：
 
 - [`v2-modernization.md`](v2-modernization.md) — 產品目標、相容性、架構及完成邊界。
 - [`validation-and-performance.md`](validation-and-performance.md) — 測試、artifact proof、benchmark及工程決定。
 - [`release-and-distribution.md`](release-and-distribution.md) — 版本、套件、發行、Overleaf及提交政策。
 
-## 記錄政策與進行中工作
+## 學生入口
 
-Durable compatibility numbers、architecture decisions、measured rejected experiments及publication boundaries會保留，因為它們限制未來維護。雙語文件工作已完成；stable language policy保留在現行文件、AGENTS、repo-local skill及deterministic checker，implementation chronology則留在Git history。目前沒有active requirement。
+如果目標是直接撰寫論文，請回到[root `README.md`](../../README.md)的需要導向入口，或閱讀學生套件的[`thesis/README.md`](../../thesis/README.md)。既有1.x專案請使用[`1.x至2.x升級指南`](../v1-to-v2-migration.md)。

--- a/scripts/test/check-bilingual-docs.py
+++ b/scripts/test/check-bilingual-docs.py
@@ -388,8 +388,20 @@ def check_project_index_scope() -> None:
         "source-of-truth",
         "feat/<short-name>",
         "branch checklist",
+        "active requirement",
+        "active work",
+        "進行中工作",
+        "implementation chronology",
+        "branch names",
+        "checkbox progress",
     )
-    for relative in ("docs/README.md", "docs/README.en.md"):
+    public_indexes = (
+        "docs/README.md",
+        "docs/README.en.md",
+        "docs/features/README.md",
+        "docs/features/README.en.md",
+    )
+    for relative in public_indexes:
         text = read(relative)
         leaked = [term for term in internal_terms if term in text]
         if leaked:
@@ -397,6 +409,16 @@ def check_project_index_scope() -> None:
                 f"{relative}: internal repository-governance content leaked "
                 f"into public index: {', '.join(leaked)}"
             )
+
+    need_based_markers = {
+        "README.md": "## 按需要開始",
+        "README.en.md": "## Start by need",
+        "docs/features/README.md": "## 按需要選擇記錄",
+        "docs/features/README.en.md": "## Choose by need",
+    }
+    for relative, marker in need_based_markers.items():
+        if marker not in read(relative):
+            fail(f"{relative}: missing need-based reader route: {marker}")
 
 
 def check_language_local_routes() -> None:


### PR DESCRIPTION
## Intent
Make the repository and shipped-feature documentation lead students to the right material for their immediate need.

## Changes
- add bilingual need-based start tables to the root README
- move quick start and setup ahead of historical/project detail while preserving required student guidance
- reorganize `docs/features/` indexes by reader question and remove active-work narration from the public index
- record the student-first public-index rule in repository governance
- extend the bilingual checker to protect need-based routes and reject internal-governance leakage from feature indexes

## Validation
- `python3 scripts/test/check-bilingual-docs.py`
- `just --fmt --check`
- `just test`
- `just ci`
- `git diff --check`

GitHub controls the alphabetical folder/file listing, so this change improves the controllable landing surface: the rendered README and documentation indexes.