### PR TITLE
fix: close approved Gallery publication

### DIFF
--- a/.agents/skills/repo-maintenance/SKILL.md
+++ b/.agents/skills/repo-maintenance/SKILL.md
@@ -292,6 +292,11 @@ are gone. Manual Release dispatch must not promote a GitHub Release.
 - Treating Overleaf's accepted community-maintained Gallery listing as NCKU
   endorsement. Keep the unofficial label, and update only through the original
   Overleaf project followed by resubmission and reapproval.
+- Searching generated Gallery packaging for the historical literal
+  `\input{./conf/conf}` after the template introduced
+  `\TemplateConfigurationFile`. Inject the Gallery overlay after
+  `\input{\TemplateConfigurationFile}` and keep a cold generated-package build
+  in the required test gate so configuration-seam drift fails before publication.
 - Publishing loose example PDFs in addition to the examples ZIP.
 - Using `legacy` in a public filename when `generated` plus a clear package
   notice communicates the institutional-document boundary more accurately.

--- a/.agents/skills/repo-maintenance/SKILL.md
+++ b/.agents/skills/repo-maintenance/SKILL.md
@@ -297,6 +297,9 @@ are gone. Manual Release dispatch must not promote a GitHub Release.
   `\TemplateConfigurationFile`. Inject the Gallery overlay after
   `\input{\TemplateConfigurationFile}` and keep a cold generated-package build
   in the required test gate so configuration-seam drift fails before publication.
+- Using macOS-only `shasum` in package verification that also runs in Alpine CI.
+  Compute SHA-256 with Python `hashlib` (already required by the verifier) so the
+  same script remains portable without another container package.
 - Publishing loose example PDFs in addition to the examples ZIP.
 - Using `legacy` in a public filename when `generated` plus a clear package
   notice communicates the institutional-document boundary more accurately.

--- a/docs/features/release-and-distribution.en.md
+++ b/docs/features/release-and-distribution.en.md
@@ -4,8 +4,8 @@
 
 # Release and distribution
 
-Status: GitHub production release verified; Overleaf Gallery V2 update last
-recorded as owner-confirmed submitted and pending public approval/read-back.
+Status: GitHub production release verified; Overleaf Gallery V2 update approved
+and independently read back from the public page, source, and PDF on 2026-07-21.
 
 - Public Overleaf template:
   <https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn>
@@ -136,6 +136,11 @@ just overleaf-gallery <version>
   `\documentclass`; nested configuration must not be auto-detected as the main
   document.
 - Both are extracted and cold-built with XeLaTeX before use.
+- The Gallery overlay is injected immediately after
+  `\input{\TemplateConfigurationFile}` so it remains compatible with the
+  default-preserving configuration seam. The required `just test` gate cold-builds
+  the generated Gallery package to prevent this source/package contract from
+  drifting again.
 
 Required Overleaf settings:
 
@@ -156,14 +161,25 @@ plan-specific timeout behavior.
   public listing was approved/published on 2026-07-15.
 - On 2026-07-18 the verified V2 Gallery package was reported as uploaded to the
   original Overleaf project and resubmitted for review.
-- The authenticated project settings and compile result were not independently
-  read back at that checkpoint. The public page still exposed the earlier copy.
-- Therefore the durable state is **owner-confirmed submitted**, not independently
-  approved V2. GitHub Releases remains canonical until the V2 Gallery copy is
-  publicly approved and independently read back.
+- On 2026-07-21 the owner supplied Overleaf's approval notice and the public
+  listing was independently read back. The public `View Source` entry point has
+  one direct root `\documentclass` and loads `./template/configure`, matching the
+  generated V2 Overleaf entry-point contract.
+- The public `Open as Template` route specifies XeLaTeX, root `thesis.tex`, and
+  TeX Live 2025.1. The isolated verification browser reached Overleaf login before
+  project creation, so this checkpoint verifies the public route parameters but
+  does not claim an authenticated fresh-project compile.
+- The public PDF read back on 2026-07-21 is 95,410 bytes, SHA-256
+  `4797e63c70f8a76c0dea6bd0142b039b0280151d1fb12e48c53c01b09f1e1c6c`,
+  11 A4 pages, and records a creation time of 2026-07-18 09:42:38 HKT. Rendered
+  inspection of the cover, abstract, and acknowledgements found complete readable
+  content with no clipping, overlap, Draft marker, or institutional watermark.
+- The durable state is therefore **approved and publicly read back**. GitHub
+  Releases remains the canonical versioned download path, while the Gallery is
+  the approved public Overleaf editing route.
 
 Before reporting a newer Overleaf state, inspect the live page, public PDF, and
-`Open as Template` result. Preserve the original project as the update identity;
+`Open as Template` route. Preserve the original project as the update identity;
 do not submit a replacement project to work around moderation.
 
 ### Overleaf limits and licensing

--- a/docs/features/release-and-distribution.md
+++ b/docs/features/release-and-distribution.md
@@ -4,7 +4,7 @@
 
 # 發行與分發
 
-狀態：GitHub production release已驗證；Overleaf Gallery V2更新仍記錄為owner-confirmed submitted，等待public approval及read-back。
+狀態：GitHub production release已驗證；Overleaf Gallery V2更新已獲批准，並於`2026-07-21`完成public page、source及PDF read-back。
 
 - [公開Overleaf範本](https://www.overleaf.com/latex/templates/national-cheng-kung-university-thesis-and-dissertation-template-xelatex/kzgwjvvptktn)
 
@@ -13,7 +13,8 @@
 - 每次production release只promote一個student ZIP及一個six-PDF examples ZIP。
 - Student ZIP等於tagged `thesis/` tree、直接解壓可用，且不包含repository tooling或多餘`thesis/`wrapper。
 - GitHub Release build／promotion及public read-back由immutable source revision及checksums連結；v2.0.2 public assets已與workflow artifact byte-identical，舊tag不會重建或移動。
-- 既有Overleaf Gallery頁面仍公開；V2狀態只可寫成owner-confirmed submitted及pending approval/read-back，不能推論已批准。
+- Overleaf Gallery V2更新已公開；public source顯示root `thesis.tex`直接宣告`\documentclass`並載入`template/configure`，公開PDF為11頁A4，封面及前置頁未見clipping、Draft marker或institution watermark。
+- `Open as Template`公開路由保留XeLaTeX、root `thesis.tex`及TeX Live 2025.1設定；隔離browser於建立project前要求登入，因此今次read-back沒有聲稱完成authenticated fresh-project compile。
 - 舊sample repository已退役，generated examples由release assets取代，不再是canonical source。
 - Draft cover marker、diagonal text watermark及institution logo watermark是三個獨立opt-ins，正式輸出全部default-off。
 - Template-generated defense certificates是unofficial demonstrations；正式提交使用學校系統文件並遵守asset/licensing boundary。

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ check: thesis
     ! grep -Eiq 'undefined references|undefined citations|Rerun to get (cross-references|outlines) right' "{{ log }}"
 
 # Run the required build and focused regression test gate.
-test: check _test-bilingual-docs _test-test-layout _test-v1-api _test-v1-project-migration _test-release-student-archive _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-numbering-family-contract _test-chapter-title-format-key-unknown _test-numbering-family-key-unknown _test-helper-values _test-deprecated-command-contract _test-float-contract _test-multi-figure-key-unknown _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-format-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-custom-institution-api _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
+test: check _test-bilingual-docs _test-test-layout _test-v1-api _test-v1-project-migration _test-release-student-archive _test-overleaf-gallery-package _test-diagnostics _test-engine-gate _test-set-thesis-date _test-sectioning-numbering _test-numbering-contract _test-numbering-family-contract _test-chapter-title-format-key-unknown _test-numbering-family-key-unknown _test-helper-values _test-deprecated-command-contract _test-float-contract _test-multi-figure-key-unknown _test-figure-key-unknown _test-table-key-unknown _test-reference-contract _test-reference-apacite-contract _test-reference-key-unknown _test-theorem-contract _test-theorem-key-unknown _test-theorem-format-key-unknown _test-theorem-style-counter _test-theorem-counter-cycle _test-custom-style _test-custom-institution-api _test-committee-size-policy _test-oral-default-state _test-metadata-bookmark _test-custom-font-files-contract _test-custom-font-files-key-unknown _test-font-option-contract _test-font-option-key-unknown _test-font-cjk _test-keyword-values _test-student-mode _test-draft-watermark-opt-in
 
 # Structural language-pair and first-party Markdown-link gate.
 [private]
@@ -117,6 +117,12 @@ _test-release-student-archive:
     grep -Fq 'student ZIP contents differ from the exact HEAD:thesis file list' "{{ build_dir }}/tests/student-archive-config-english-negative.log"
     grep -Fq -- '-ncku-thesis-template-latex/conf/README.en.md' "{{ build_dir }}/tests/student-archive-config-english-negative.log"
     rm -f "{{ build_dir }}/tests/student-archive-config-english-negative.zip"
+
+# Internal regression test for the generated public Gallery package and overlay.
+[private]
+_test-overleaf-gallery-package:
+    rm -rf "{{ build_dir }}/tests/overleaf-gallery"
+    scripts/overleaf/package-and-verify.sh "test" "{{ build_dir }}/tests/overleaf-gallery" gallery
 
 # Internal regression budget for final canonical-build diagnostics.
 [private]

--- a/scripts/overleaf/package-and-verify.sh
+++ b/scripts/overleaf/package-and-verify.sh
@@ -202,5 +202,17 @@ if elapsed > 10:
     print("WARNING: local cold build exceeds Overleaf free-plan 10-second timeout; an authenticated Overleaf build is required", file=sys.stderr)
 PY
 
-sha256=$(shasum -a 256 "$output_dir_abs/$archive_name" | awk '{print $1}')
+sha256=$(python3 - "$output_dir_abs/$archive_name" <<'PY'
+from pathlib import Path
+import hashlib
+import sys
+
+archive = Path(sys.argv[1])
+digest = hashlib.sha256()
+with archive.open("rb") as stream:
+    for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+PY
+)
 printf 'Overleaf package: %s\nSHA-256: %s\n' "$output_dir_abs/$archive_name" "$sha256"

--- a/scripts/overleaf/package-and-verify.sh
+++ b/scripts/overleaf/package-and-verify.sh
@@ -82,11 +82,14 @@ if configure_text.count(configure_needle) != 1:
 configure.write_text(configure_text.replace(configure_needle, ""), encoding="utf-8")
 if profile == "gallery":
     configure_text = configure.read_text(encoding="utf-8")
-    conf_needle = "\\input{./conf/conf}\n"
-    if configure_text.count(conf_needle) != 1:
-        raise SystemExit("expected one canonical config input")
+    configuration_needle = "\\input{\\TemplateConfigurationFile}\n"
+    if configure_text.count(configuration_needle) != 1:
+        raise SystemExit("expected one template configuration input")
     configure.write_text(
-        configure_text.replace(conf_needle, conf_needle + "\\input{./conf/gallery}\n"),
+        configure_text.replace(
+            configuration_needle,
+            configuration_needle + "\\input{./conf/gallery}\n",
+        ),
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Intent

Close the approved Overleaf Gallery publication record and restore reproducible Gallery packaging without changing thesis output or the Overleaf-controlled licence label.

## Changes

- inject the Gallery overlay after `\input{\TemplateConfigurationFile}` instead of matching the retired literal configuration path;
- add a required cold generated-Gallery-package regression to `just test`;
- record the approved public Gallery page, source, PDF, and route read-back in the bilingual release/distribution record;
- preserve the authenticated fresh-project compile boundary: public route parameters were verified, but the isolated browser required login before project creation;
- capture the configuration-seam packaging pitfall in the repo-local maintenance skill.

## Validation

- `bash -n scripts/overleaf/package-and-verify.sh`
- `just --fmt --check`
- `python3 scripts/test/check-bilingual-docs.py`
- `just ci`
- clean committed `just overleaf approved-20260721`
- clean committed `just overleaf-gallery approved-20260721`
- public Gallery page/source/PDF read-back and rendered cover/front-matter inspection
- `git diff --check`

## Boundaries

- no thesis source or visible-output change;
- no generated ZIP/PDF committed;
- no GitHub release or tag;
- no Overleaf project mutation;
- no merge or branch deletion in this PR creation step.

## Hosted validation

- current-head push Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29801754589
- current-head pull-request Test: https://github.com/wengan-li/ncku-thesis-template-latex/actions/runs/29801756477
- tested head: `0c76e8c5b2a386551b3acc3c7a2cea145079c2f0`
